### PR TITLE
Add CodeQL and e2e CI workflows

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,40 @@
+name: E2E Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 4 * * *" # Nightly at 04:00 UTC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: read-all
+
+jobs:
+  e2e:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install controller-gen
+        run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+
+      - name: Create Kubernetes cluster
+        uses: palmsoftware/quick-k8s@2c50b3118203c1e1ce511c9306e25eec83a619be # v0.0.58
+        with:
+          numControlPlaneNodes: 1
+          numWorkerNodes: 1
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run e2e tests
+        run: make test-e2e IMG=quay.io/redhat-best-practices-for-k8s/bps-operator:e2e

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
@@ -40,5 +43,6 @@ jobs:
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.tags.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24 AS builder
+FROM golang:1.26 AS builder
 
 WORKDIR /workspace
 COPY go.mod go.sum ./

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 IMG ?= quay.io/redhat-best-practices-for-k8s/bps-operator:latest
 OPERATOR_NAMESPACE ?= bps-operator-system
 TEST_NAMESPACE ?= bps-test
+KIND_CLUSTER_NAME ?= kind
 
 # Use oc if available, fall back to kubectl
 KUBECTL ?= $(shell command -v oc 2>/dev/null || echo kubectl)
@@ -32,6 +33,38 @@ generate:
 .PHONY: manifests
 manifests:
 	controller-gen rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+
+.PHONY: test-e2e
+test-e2e: build-image ## Run e2e tests against a Kind cluster
+	@echo "Loading image into Kind cluster..."
+	kind load docker-image $(IMG) --name $(KIND_CLUSTER_NAME)
+	$(MAKE) deploy
+	$(KUBECTL) set image deployment/bps-operator-controller-manager manager=$(IMG) -n $(OPERATOR_NAMESPACE)
+	$(KUBECTL) patch deployment bps-operator-controller-manager -n $(OPERATOR_NAMESPACE) \
+		-p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"IfNotPresent"}]}}}}'
+	@echo "Waiting for operator to be ready..."
+	$(KUBECTL) rollout status deployment/bps-operator-controller-manager -n $(OPERATOR_NAMESPACE) --timeout=120s
+	$(KUBECTL) apply -f config/samples/test-workloads.yaml
+	$(KUBECTL) wait --for=jsonpath='{.status.phase}'=Active namespace/$(TEST_NAMESPACE) --timeout=10s
+	$(KUBECTL) apply -f config/samples/scanner_bps_test.yaml
+	@echo "Waiting for scan to complete..."
+	@for i in $$(seq 1 90); do \
+		PHASE=$$($(KUBECTL) get bestpracticescanners test-scanner -n $(TEST_NAMESPACE) -o jsonpath='{.status.phase}' 2>/dev/null); \
+		if [ "$$PHASE" = "Completed" ]; then echo "Scan completed."; break; fi; \
+		if [ $$i -eq 90 ]; then \
+			echo "Timed out waiting for scan (phase: $$PHASE)"; \
+			echo "=== Operator Logs ==="; \
+			$(KUBECTL) logs deployment/bps-operator-controller-manager -n $(OPERATOR_NAMESPACE) --tail=50 2>/dev/null || true; \
+			echo "=== Scanner Status ==="; \
+			$(KUBECTL) get bestpracticescanners test-scanner -n $(TEST_NAMESPACE) -o yaml 2>/dev/null || true; \
+			echo "=== Pod Status ==="; \
+			$(KUBECTL) get pods -A 2>/dev/null || true; \
+			exit 1; \
+		fi; \
+		sleep 2; \
+	done
+	@echo "=== E2E Results ==="
+	@$(KUBECTL) get bestpracticeresults -n $(TEST_NAMESPACE)
 
 .PHONY: build-image
 build-image:

--- a/config/rbac/rolebinding.yaml
+++ b/config/rbac/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: manager-role
+subjects:
+- kind: ServiceAccount
+  name: bps-operator-controller-manager
+  namespace: bps-operator-system

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sebrandon1/bps-operator
 
-go 1.24.0
+go 1.26.1
 
 require (
 	k8s.io/api v0.32.3


### PR DESCRIPTION
## Summary

- Add CodeQL security scanning workflow (push to main, PRs, weekly Monday schedule)
- Add e2e test workflow using `palmsoftware/quick-k8s` Kind clusters (push to main, PRs, nightly)
- Add `make test-e2e` target that builds the image, loads into Kind, deploys the operator, runs a scan, and verifies results
- All GitHub Actions are SHA-pinned following certsuite conventions

## Test plan

- [ ] CI workflows trigger on this PR (pre-main, CodeQL, e2e)
- [ ] CodeQL analysis completes without findings
- [ ] E2e test creates Kind cluster, deploys operator, and runs scan successfully
- [ ] Nightly schedule triggers after merge