### PR TITLE
Update image registry and add disk-pressure toleration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMG ?= quay.io/redhat-best-practices-for-k8s/bps-operator:latest
+IMG ?= quay.io/bapalm/bps-operator:latest
 OPERATOR_NAMESPACE ?= bps-operator-system
 TEST_NAMESPACE ?= bps-test
 KIND_CLUSTER_NAME ?= kind

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,9 +27,13 @@ spec:
         app.kubernetes.io/name: bps-operator
     spec:
       serviceAccountName: bps-operator-controller-manager
+      tolerations:
+        - key: node.kubernetes.io/disk-pressure
+          operator: Exists
+          effect: NoSchedule
       containers:
         - name: manager
-          image: quay.io/redhat-best-practices-for-k8s/bps-operator:latest
+          image: quay.io/bapalm/bps-operator:latest
           args:
             - --operator-namespace=bps-operator-system
           ports:


### PR DESCRIPTION
## Summary

- Update default image reference from `quay.io/redhat-best-practices-for-k8s/bps-operator:latest` to `quay.io/bapalm/bps-operator:latest`
- Add `node.kubernetes.io/disk-pressure` toleration to operator deployment to support constrained development environments like CRC

## Changes

- **Makefile**: Update IMG variable to point to `quay.io/bapalm/bps-operator:latest`
- **config/manager/manager.yaml**: 
  - Update image reference to `quay.io/bapalm/bps-operator:latest`
  - Add disk-pressure toleration to pod spec

## Test plan

- [x] Built image locally
- [x] Pushed to internal CRC registry and tested deployment
- [x] Verified operator starts and runs successfully with disk-pressure taint
- [ ] Push image to quay.io/bapalm/bps-operator:latest
- [ ] Verify deployment works with published image