### PR TITLE
Add Kubernetes Events and Status Conditions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,34 @@ test-e2e: build-image ## Run e2e tests against a Kind cluster
 	done
 	@echo "=== E2E Results ==="
 	@$(KUBECTL) get bestpracticeresults -n $(TEST_NAMESPACE)
+	@echo ""
+	@echo "=== Verify Events ==="
+	@EVENTS=$$($(KUBECTL) get events -n $(TEST_NAMESPACE) --field-selector reason=ScanCompleted -o jsonpath='{.items}' 2>/dev/null); \
+	if [ "$$EVENTS" = "[]" ] || [ -z "$$EVENTS" ]; then \
+		echo "FAIL: No ScanCompleted event found"; exit 1; \
+	else \
+		echo "PASS: ScanCompleted event found"; \
+	fi
+	@echo ""
+	@echo "=== Verify Conditions ==="
+	@CONDITION=$$($(KUBECTL) get bestpracticescanners test-scanner -n $(TEST_NAMESPACE) -o jsonpath='{.status.conditions[?(@.type=="ScanComplete")].status}' 2>/dev/null); \
+	if [ "$$CONDITION" != "True" ]; then \
+		echo "FAIL: ScanComplete condition is not True (got: $$CONDITION)"; exit 1; \
+	else \
+		echo "PASS: ScanComplete condition is True"; \
+	fi
+	@echo ""
+	@echo "=== Verify Metrics ==="
+	@$(KUBECTL) port-forward -n $(OPERATOR_NAMESPACE) deployment/bps-operator-controller-manager 18080:8080 &>/dev/null & \
+	PF_PID=$$!; \
+	sleep 2; \
+	METRICS=$$(curl -s http://localhost:18080/metrics 2>/dev/null | grep bps_scans_total || true); \
+	kill $$PF_PID 2>/dev/null; wait $$PF_PID 2>/dev/null; \
+	if [ -z "$$METRICS" ]; then \
+		echo "FAIL: bps_scans_total metric not found"; exit 1; \
+	else \
+		echo "PASS: Metrics available"; echo "  $$METRICS"; \
+	fi
 
 .PHONY: build-image
 build-image:

--- a/api/v1alpha1/bestpracticescanner_types.go
+++ b/api/v1alpha1/bestpracticescanner_types.go
@@ -57,11 +57,33 @@ type ScanSummary struct {
 	Skipped int `json:"skipped"`
 }
 
+// Condition type constants for BestPracticeScanner.
+const (
+	ConditionScanComplete   = "ScanComplete"
+	ConditionProbeAvailable = "ProbeAvailable"
+)
+
+// Condition and event reason constants for BestPracticeScanner.
+const (
+	ReasonScanStarted     = "ScanStarted"
+	ReasonScanSucceeded   = "ScanSucceeded"
+	ReasonScanFailed      = "ScanFailed"
+	ReasonScanCompleted   = "ScanCompleted"
+	ReasonProbePodsReady  = "ProbePodsReady"
+	ReasonProbePodsFailed = "ProbePodsFailed"
+	ReasonProbeUnavailable = "ProbeUnavailable"
+)
+
 // BestPracticeScannerStatus defines the observed state of BestPracticeScanner.
 type BestPracticeScannerStatus struct {
 	// Phase is the current phase of the scanner.
 	// +optional
 	Phase ScannerPhase `json:"phase,omitempty"`
+	// Conditions represent the latest available observations of the scanner's state.
+	// +optional
+	// +listType=map
+	// +listMapKey=type
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 	// LastScanTime is the timestamp of the last completed scan.
 	// +optional
 	LastScanTime *metav1.Time `json:"lastScanTime,omitempty"`

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -132,6 +132,7 @@ func run(opts options, cfg *rest.Config) error {
 	if err := (&controller.ScannerReconciler{
 		Client:            mgr.GetClient(),
 		Scheme:            mgr.GetScheme(),
+		Recorder:          mgr.GetEventRecorderFor("scanner"),
 		ProbeExecutor:     probeExecutor,
 		OperatorNamespace: opts.operatorNamespace,
 		ProbeImage:        opts.probeImage,

--- a/config/crd/bases/bps.openshift.io_bestpracticescanners.yaml
+++ b/config/crd/bases/bps.openshift.io_bestpracticescanners.yaml
@@ -131,6 +131,67 @@ spec:
           status:
             description: BestPracticeScannerStatus defines the observed state of BestPracticeScanner.
             properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the scanner's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               lastScanTime:
                 description: LastScanTime is the timestamp of the last completed scan.
                 format: date-time

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   - persistentvolumes
   - resourcequotas

--- a/internal/controller/scanner_controller.go
+++ b/internal/controller/scanner_controller.go
@@ -5,10 +5,13 @@ import (
 	"fmt"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -25,6 +28,7 @@ import (
 type ScannerReconciler struct {
 	client.Client
 	Scheme            *runtime.Scheme
+	Recorder          record.EventRecorder
 	ProbeExecutor     checks.ProbeExecutor
 	OperatorNamespace string
 	ProbeImage        string
@@ -55,6 +59,7 @@ type ScannerReconciler struct {
 // +kubebuilder:rbac:groups=apiserver.openshift.io,resources=apirequestcounts,verbs=get;list;watch
 // +kubebuilder:rbac:groups=k8s.cni.cncf.io,resources=network-attachment-definitions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=sriovnetwork.openshift.io,resources=sriovnetworks;sriovnetworknodepolicies,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
 func (r *ScannerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
@@ -116,15 +121,24 @@ func (r *ScannerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Set phase to Scanning
 	scannerCR.Status.Phase = bpsv1alpha1.PhaseScanning
+	meta.SetStatusCondition(&scannerCR.Status.Conditions, metav1.Condition{
+		Type:               bpsv1alpha1.ConditionScanComplete,
+		Status:             metav1.ConditionFalse,
+		Reason:             bpsv1alpha1.ReasonScanStarted,
+		Message:            "Compliance scan in progress",
+		ObservedGeneration: scannerCR.Generation,
+	})
 	if err := r.Status().Update(ctx, &scannerCR); err != nil {
 		return ctrl.Result{}, err
 	}
+	r.Recorder.Event(&scannerCR, corev1.EventTypeNormal, bpsv1alpha1.ReasonScanStarted, "Starting compliance scan")
 
 	// Discover and run checks
 	scanStart := time.Now()
 
 	resources, err := r.discoverResources(ctx, &scannerCR, targetNS)
 	if err != nil {
+		r.Recorder.Eventf(&scannerCR, corev1.EventTypeWarning, bpsv1alpha1.ReasonScanFailed, "Resource discovery failed: %v", err)
 		return ctrl.Result{}, err
 	}
 
@@ -177,6 +191,13 @@ func (r *ScannerReconciler) discoverResources(ctx context.Context, scannerCR *bp
 	resources, err := scanner.Discover(ctx, r.Client, targetNS, scannerCR.Spec.LabelSelector, r.DiscoveryClient)
 	if err != nil {
 		scannerCR.Status.Phase = bpsv1alpha1.PhaseError
+		meta.SetStatusCondition(&scannerCR.Status.Conditions, metav1.Condition{
+			Type:               bpsv1alpha1.ConditionScanComplete,
+			Status:             metav1.ConditionFalse,
+			Reason:             bpsv1alpha1.ReasonScanFailed,
+			Message:            fmt.Sprintf("Resource discovery failed: %v", err),
+			ObservedGeneration: scannerCR.Generation,
+		})
 		if updateErr := r.Status().Update(ctx, scannerCR); updateErr != nil {
 			logger.Error(updateErr, "Failed to update scanner status to Error")
 		}
@@ -194,9 +215,24 @@ func (r *ScannerReconciler) discoverResources(ctx context.Context, scannerCR *bp
 		probePods, err := probe.MapProbePods(ctx, r.Client, r.OperatorNamespace)
 		if err != nil {
 			logger.Error(err, "Failed to map probe pods, probe-based checks will be skipped")
+			r.Recorder.Event(scannerCR, corev1.EventTypeWarning, bpsv1alpha1.ReasonProbeUnavailable, "Probe pods not available, probe-based checks will be skipped")
+			meta.SetStatusCondition(&scannerCR.Status.Conditions, metav1.Condition{
+				Type:               bpsv1alpha1.ConditionProbeAvailable,
+				Status:             metav1.ConditionFalse,
+				Reason:             bpsv1alpha1.ReasonProbePodsFailed,
+				Message:            err.Error(),
+				ObservedGeneration: scannerCR.Generation,
+			})
 		} else {
 			resources.ProbePods = probePods
 			resources.ProbeExecutor = r.ProbeExecutor
+			meta.SetStatusCondition(&scannerCR.Status.Conditions, metav1.Condition{
+				Type:               bpsv1alpha1.ConditionProbeAvailable,
+				Status:             metav1.ConditionTrue,
+				Reason:             bpsv1alpha1.ReasonProbePodsReady,
+				Message:            fmt.Sprintf("%d probe pods available", len(probePods)),
+				ObservedGeneration: scannerCR.Generation,
+			})
 		}
 	}
 
@@ -311,6 +347,14 @@ func (r *ScannerReconciler) completeScan(ctx context.Context, req ctrl.Request, 
 	scannerCR.Status.LastScanTime = &now
 	scannerCR.Status.Summary = &summary
 
+	meta.SetStatusCondition(&scannerCR.Status.Conditions, metav1.Condition{
+		Type:               bpsv1alpha1.ConditionScanComplete,
+		Status:             metav1.ConditionTrue,
+		Reason:             bpsv1alpha1.ReasonScanSucceeded,
+		Message:            fmt.Sprintf("%d checks: %d compliant, %d non-compliant, %d skipped, %d errors", summary.Total, summary.Compliant, summary.NonCompliant, summary.Skipped, summary.Error),
+		ObservedGeneration: scannerCR.Generation,
+	})
+
 	var requeueAfter time.Duration
 	if scanInterval > 0 {
 		requeueAfter = scanInterval
@@ -321,6 +365,10 @@ func (r *ScannerReconciler) completeScan(ctx context.Context, req ctrl.Request, 
 	if err := r.Status().Update(ctx, scannerCR); err != nil {
 		return ctrl.Result{}, err
 	}
+
+	r.Recorder.Eventf(scannerCR, corev1.EventTypeNormal, bpsv1alpha1.ReasonScanCompleted,
+		"Scan completed: %d compliant, %d non-compliant, %d skipped, %d errors (%.1fs)",
+		summary.Compliant, summary.NonCompliant, summary.Skipped, summary.Error, scanDuration.Seconds())
 
 	logger.Info("Scan completed",
 		"total", summary.Total,

--- a/internal/controller/scanner_controller_test.go
+++ b/internal/controller/scanner_controller_test.go
@@ -14,6 +14,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -43,7 +44,7 @@ func TestReconcile_ScannerNotFound(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
 
-	r := &ScannerReconciler{Client: c, Scheme: s}
+	r := &ScannerReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "missing", Namespace: "test"},
 	})
@@ -67,7 +68,7 @@ func TestReconcile_Suspend(t *testing.T) {
 		WithStatusSubresource(scanner).
 		Build()
 
-	r := &ScannerReconciler{Client: c, Scheme: s}
+	r := &ScannerReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test-scanner", Namespace: "test-ns"},
 	})
@@ -108,7 +109,7 @@ func TestReconcile_FullScan(t *testing.T) {
 		WithStatusSubresource(scanner).
 		Build()
 
-	r := &ScannerReconciler{Client: c, Scheme: s}
+	r := &ScannerReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "scanner", Namespace: "ns"},
 	})
@@ -171,7 +172,7 @@ func TestReconcile_NonCompliant(t *testing.T) {
 		WithStatusSubresource(scanner).
 		Build()
 
-	r := &ScannerReconciler{Client: c, Scheme: s}
+	r := &ScannerReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "scanner", Namespace: "ns"},
 	})
@@ -210,7 +211,7 @@ func TestReconcile_WithScanInterval(t *testing.T) {
 		WithStatusSubresource(scanner).
 		Build()
 
-	r := &ScannerReconciler{Client: c, Scheme: s}
+	r := &ScannerReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "scanner", Namespace: "ns"},
 	})


### PR DESCRIPTION
## Summary

- Add event recorder emitting events at key state transitions: `ScanStarted`, `ScanCompleted`, `ScanFailed`, `ProbeUnavailable`
- Add `Conditions []metav1.Condition` to scanner status with two condition types:
  - `ScanComplete` — whether the latest scan finished successfully
  - `ProbeAvailable` — whether probe DaemonSet pods are running
- Define reason constants in API package for type safety
- Preserve `Phase` field for backward compatibility
- Regenerate CRD and RBAC manifests (events permission added)

Users can now see scan history via `kubectl describe bestpracticescanner` and programmatically watch conditions.

Closes #23, closes #24

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test` — all tests pass
- [x] `make manifests` — CRD includes conditions schema, RBAC includes events permission