### PR TITLE
build(deps): bump checks library to v0.0.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/operator-framework/api v0.42.0
 	github.com/operator-framework/operator-lifecycle-manager v0.41.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/redhat-best-practices-for-k8s/checks v0.0.5
+	github.com/redhat-best-practices-for-k8s/checks v0.0.7
 	k8s.io/api v0.35.3
 	k8s.io/apiextensions-apiserver v0.35.3
 	k8s.io/apimachinery v0.35.3

--- a/go.sum
+++ b/go.sum
@@ -265,8 +265,8 @@ github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEo
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
-github.com/redhat-best-practices-for-k8s/checks v0.0.5 h1:qRHI04KFclueHguY8lY0ftYIOyhKksgodO9WQuthIJA=
-github.com/redhat-best-practices-for-k8s/checks v0.0.5/go.mod h1:YwfIgMvmM/p4MSRSV/+YZw3ddC71Oq7eXxKyKOAHrq8=
+github.com/redhat-best-practices-for-k8s/checks v0.0.7 h1:dVfVhEP4X8QT0FPvtfUj8913NrC1jTuYUZG/JxZmBu4=
+github.com/redhat-best-practices-for-k8s/checks v0.0.7/go.mod h1:boHKdpsZiBUXM36+6gRpL88x4s80bzELUqCPqqy5CPA=
 github.com/redis/go-redis/extra/rediscmd/v9 v9.17.3 h1:v9RNP5ynWkruvzscrIoDyyv20c9YeyVn12L9nYnaexw=
 github.com/redis/go-redis/extra/rediscmd/v9 v9.17.3/go.mod h1:gdthSemCkR3WxTmzV2XxYIxClunkUJZAhL0zPHaB0Ww=
 github.com/redis/go-redis/extra/redisotel/v9 v9.17.3 h1:bF0e3fV7PL0knd1UHDtMud8wA7CZt3RSWtyTMhpnWd8=


### PR DESCRIPTION
## Summary

- Bump checks library from v0.0.5 to v0.0.7

## Changes in checks library

- **v0.0.6**: Full check metadata (tags, category classifications, impact statements, doc links, exception processes, QE flag)
- **v0.0.7**: Check functions return Compliant instead of Skipped when there are no resources to validate

## Test plan

- [x] go build ./... passes
- [x] go test ./... all tests pass