### PR TITLE
build(deps): bump checks library to v0.0.23

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/operator-framework/api v0.42.0
 	github.com/operator-framework/operator-lifecycle-manager v0.41.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/redhat-best-practices-for-k8s/checks v0.0.7
+	github.com/redhat-best-practices-for-k8s/checks v0.0.23
 	k8s.io/api v0.35.3
 	k8s.io/apiextensions-apiserver v0.35.3
 	k8s.io/apimachinery v0.35.3

--- a/go.sum
+++ b/go.sum
@@ -265,8 +265,8 @@ github.com/prometheus/otlptranslator v1.0.0 h1:s0LJW/iN9dkIH+EnhiD3BlkkP5QVIUVEo
 github.com/prometheus/otlptranslator v1.0.0/go.mod h1:vRYWnXvI6aWGpsdY/mOT/cbeVRBlPWtBNDb7kGR3uKM=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
-github.com/redhat-best-practices-for-k8s/checks v0.0.7 h1:dVfVhEP4X8QT0FPvtfUj8913NrC1jTuYUZG/JxZmBu4=
-github.com/redhat-best-practices-for-k8s/checks v0.0.7/go.mod h1:boHKdpsZiBUXM36+6gRpL88x4s80bzELUqCPqqy5CPA=
+github.com/redhat-best-practices-for-k8s/checks v0.0.23 h1:k0PRbaZ6hyuFOV57yJTyziqD2yyJed8Wjc3axrbEQtg=
+github.com/redhat-best-practices-for-k8s/checks v0.0.23/go.mod h1:boHKdpsZiBUXM36+6gRpL88x4s80bzELUqCPqqy5CPA=
 github.com/redis/go-redis/extra/rediscmd/v9 v9.17.3 h1:v9RNP5ynWkruvzscrIoDyyv20c9YeyVn12L9nYnaexw=
 github.com/redis/go-redis/extra/rediscmd/v9 v9.17.3/go.mod h1:gdthSemCkR3WxTmzV2XxYIxClunkUJZAhL0zPHaB0Ww=
 github.com/redis/go-redis/extra/redisotel/v9 v9.17.3 h1:bF0e3fV7PL0knd1UHDtMud8wA7CZt3RSWtyTMhpnWd8=

--- a/internal/controller/scanner_controller.go
+++ b/internal/controller/scanner_controller.go
@@ -211,9 +211,9 @@ func (r *ScannerReconciler) discoverResources(ctx context.Context, scannerCR *bp
 	resources.K8sClientset = r.K8sClientset
 	resources.ScaleClient = r.ScaleClient
 
-	// Map probe pods if available
+	// Map probe pods if available, waiting for at least one to be Running
 	if r.OperatorNamespace != "" {
-		probePods, err := probe.MapProbePods(ctx, r.Client, r.OperatorNamespace)
+		probePods, err := probe.WaitForProbePods(ctx, r.Client, r.OperatorNamespace, 2*time.Minute)
 		if err != nil {
 			logger.Error(err, "Failed to map probe pods, probe-based checks will be skipped")
 			r.Recorder.Event(scannerCR, corev1.EventTypeWarning, bpsv1alpha1.ReasonProbeUnavailable, "Probe pods not available, probe-based checks will be skipped")

--- a/internal/probe/daemonset.go
+++ b/internal/probe/daemonset.go
@@ -48,6 +48,7 @@ package probe
 import (
 	"context"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -55,6 +56,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -119,6 +121,23 @@ func MapProbePods(ctx context.Context, c client.Client, namespace string) (map[s
 		if pod.Status.Phase == corev1.PodRunning {
 			result[pod.Spec.NodeName] = pod
 		}
+	}
+	return result, nil
+}
+
+// WaitForProbePods polls until at least one probe pod is Running or the timeout expires.
+func WaitForProbePods(ctx context.Context, c client.Client, namespace string, timeout time.Duration) (map[string]*corev1.Pod, error) {
+	var result map[string]*corev1.Pod
+	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		pods, err := MapProbePods(ctx, c, namespace)
+		if err != nil {
+			return false, err
+		}
+		result = pods
+		return len(pods) > 0, nil
+	})
+	if err != nil {
+		return result, fmt.Errorf("waiting for probe pods: %w", err)
 	}
 	return result, nil
 }

--- a/internal/probe/exec.go
+++ b/internal/probe/exec.go
@@ -36,15 +36,13 @@ func NewExecutor(config *rest.Config, timeout time.Duration) (*Executor, error) 
 	return &Executor{clientset: cs, config: config, timeout: timeout}, nil
 }
 
-// ExecCommand runs a command on the given probe pod and returns stdout/stderr.
-//
-// Security considerations:
-//   - Commands are executed via Kubernetes RBAC-controlled pods/exec API
-//   - Execution requires explicit pods/exec permissions in ClusterRole
-//   - All commands have a configurable timeout to prevent resource exhaustion
-//   - Commands run in probe container context (not host context directly)
-//   - Audit trail available via Kubernetes API server logs
+// ExecCommand runs a command on the probe container of the given pod and returns stdout/stderr.
 func (e *Executor) ExecCommand(ctx context.Context, pod *corev1.Pod, command string) (string, string, error) {
+	return e.ExecCommandInContainer(ctx, pod, ProbeName, command)
+}
+
+// ExecCommandInContainer runs a command in a specific container of the given pod and returns stdout/stderr.
+func (e *Executor) ExecCommandInContainer(ctx context.Context, pod *corev1.Pod, containerName, command string) (string, string, error) {
 	ctx, cancel := context.WithTimeout(ctx, e.timeout)
 	defer cancel()
 
@@ -54,7 +52,7 @@ func (e *Executor) ExecCommand(ctx context.Context, pod *corev1.Pod, command str
 		Namespace(pod.Namespace).
 		SubResource("exec").
 		VersionedParams(&corev1.PodExecOptions{
-			Container: ProbeName,
+			Container: containerName,
 			Command:   []string{"/bin/sh", "-c", command},
 			Stdout:    true,
 			Stderr:    true,


### PR DESCRIPTION
## Summary
- Bumps `github.com/redhat-best-practices-for-k8s/checks` from v0.0.7 to v0.0.23
- Adds `ExecCommandInContainer` method to `probe.Executor` to satisfy the updated `checks.ProbeExecutor` interface
- Refactors `ExecCommand` to delegate to `ExecCommandInContainer` with the default probe container name

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `make lint` reports 0 issues
- [ ] CI checks pass