### PR TITLE
refactor: replace blocking probe wait with non-blocking requeue

### DIFF
--- a/internal/controller/scanner_controller.go
+++ b/internal/controller/scanner_controller.go
@@ -2,11 +2,12 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,6 +41,10 @@ type ScannerReconciler struct {
 	CatalogURLBase    string
 }
 
+const probeRequeueInterval = 5 * time.Second
+
+var errProbesPending = fmt.Errorf("probe pods not yet running")
+
 // +kubebuilder:rbac:groups=bps.openshift.io,resources=bestpracticescanners,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=bps.openshift.io,resources=bestpracticescanners/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=bps.openshift.io,resources=bestpracticescanners/finalizers,verbs=update
@@ -68,7 +73,7 @@ func (r *ScannerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Fetch the BestPracticeScanner CR
 	var scannerCR bpsv1alpha1.BestPracticeScanner
 	if err := r.Get(ctx, req.NamespacedName, &scannerCR); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
@@ -138,6 +143,10 @@ func (r *ScannerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	scanStart := time.Now()
 
 	resources, err := r.discoverResources(ctx, &scannerCR, targetNS)
+	if errors.Is(err, errProbesPending) {
+		logger.Info("Probe pods not yet running, requeueing")
+		return ctrl.Result{RequeueAfter: probeRequeueInterval}, nil
+	}
 	if err != nil {
 		r.Recorder.Eventf(&scannerCR, corev1.EventTypeWarning, bpsv1alpha1.ReasonScanFailed, "Resource discovery failed: %v", err)
 		return ctrl.Result{}, err
@@ -178,7 +187,6 @@ func (r *ScannerReconciler) enforceUniqueness(ctx context.Context, scannerCR *bp
 	return nil
 }
 
-// discoverResources discovers cluster resources and wires probe/certification fields.
 func (r *ScannerReconciler) discoverResources(ctx context.Context, scannerCR *bpsv1alpha1.BestPracticeScanner, targetNS string) (*checks.DiscoveredResources, error) {
 	logger := log.FromContext(ctx)
 
@@ -211,9 +219,8 @@ func (r *ScannerReconciler) discoverResources(ctx context.Context, scannerCR *bp
 	resources.K8sClientset = r.K8sClientset
 	resources.ScaleClient = r.ScaleClient
 
-	// Map probe pods if available, waiting for at least one to be Running
 	if r.OperatorNamespace != "" {
-		probePods, err := probe.WaitForProbePods(ctx, r.Client, r.OperatorNamespace, 2*time.Minute)
+		probePods, err := probe.MapProbePods(ctx, r.Client, r.OperatorNamespace)
 		if err != nil {
 			logger.Error(err, "Failed to map probe pods, probe-based checks will be skipped")
 			r.Recorder.Event(scannerCR, corev1.EventTypeWarning, bpsv1alpha1.ReasonProbeUnavailable, "Probe pods not available, probe-based checks will be skipped")
@@ -224,6 +231,8 @@ func (r *ScannerReconciler) discoverResources(ctx context.Context, scannerCR *bp
 				Message:            err.Error(),
 				ObservedGeneration: scannerCR.Generation,
 			})
+		} else if len(probePods) == 0 {
+			return nil, errProbesPending
 		} else {
 			resources.ProbePods = probePods
 			resources.ProbeExecutor = r.ProbeExecutor
@@ -406,7 +415,7 @@ func (r *ScannerReconciler) deleteStaleResults(ctx context.Context, scannerCR *b
 	for i := range resultList.Items {
 		result := &resultList.Items[i]
 		if !currentNames[result.Name] {
-			if err := r.Delete(ctx, result); err != nil && !errors.IsNotFound(err) {
+			if err := r.Delete(ctx, result); err != nil && !apierrors.IsNotFound(err) {
 				return err
 			}
 		}

--- a/internal/probe/daemonset.go
+++ b/internal/probe/daemonset.go
@@ -48,7 +48,6 @@ package probe
 import (
 	"context"
 	"fmt"
-	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -56,7 +55,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -105,7 +103,6 @@ func DeleteDaemonSet(ctx context.Context, c client.Client, namespace string) err
 	return err
 }
 
-// MapProbePods returns a map of node name to probe pod for all running probe pods.
 func MapProbePods(ctx context.Context, c client.Client, namespace string) (map[string]*corev1.Pod, error) {
 	var podList corev1.PodList
 	if err := c.List(ctx, &podList,
@@ -121,23 +118,6 @@ func MapProbePods(ctx context.Context, c client.Client, namespace string) (map[s
 		if pod.Status.Phase == corev1.PodRunning {
 			result[pod.Spec.NodeName] = pod
 		}
-	}
-	return result, nil
-}
-
-// WaitForProbePods polls until at least one probe pod is Running or the timeout expires.
-func WaitForProbePods(ctx context.Context, c client.Client, namespace string, timeout time.Duration) (map[string]*corev1.Pod, error) {
-	var result map[string]*corev1.Pod
-	err := wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
-		pods, err := MapProbePods(ctx, c, namespace)
-		if err != nil {
-			return false, err
-		}
-		result = pods
-		return len(pods) > 0, nil
-	})
-	if err != nil {
-		return result, fmt.Errorf("waiting for probe pods: %w", err)
 	}
 	return result, nil
 }

--- a/internal/probe/exec.go
+++ b/internal/probe/exec.go
@@ -36,12 +36,10 @@ func NewExecutor(config *rest.Config, timeout time.Duration) (*Executor, error) 
 	return &Executor{clientset: cs, config: config, timeout: timeout}, nil
 }
 
-// ExecCommand runs a command on the probe container of the given pod and returns stdout/stderr.
 func (e *Executor) ExecCommand(ctx context.Context, pod *corev1.Pod, command string) (string, string, error) {
 	return e.ExecCommandInContainer(ctx, pod, ProbeName, command)
 }
 
-// ExecCommandInContainer runs a command in a specific container of the given pod and returns stdout/stderr.
 func (e *Executor) ExecCommandInContainer(ctx context.Context, pod *corev1.Pod, containerName, command string) (string, string, error) {
 	ctx, cancel := context.WithTimeout(ctx, e.timeout)
 	defer cancel()


### PR DESCRIPTION
## Summary
- Replace `WaitForProbePods` (2-minute blocking poll inside reconcile loop) with non-blocking `MapProbePods` + `RequeueAfter: 5s`
- Remove `WaitForProbePods` function and unused `time`/`wait` imports from `daemonset.go`
- Remove redundant WHAT comments on `ExecCommand`, `ExecCommandInContainer`, `MapProbePods`, and `discoverResources`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `make lint` reports 0 issues
- [ ] CI checks pass