### PR TITLE
ci: add checks-qe e2e workflows

### DIFF
--- a/.github/workflows/e2e-checks-qe-ocp.yaml
+++ b/.github/workflows/e2e-checks-qe-ocp.yaml
@@ -1,0 +1,98 @@
+name: E2E checks-qe OCP Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 4 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: read-all
+
+jobs:
+  e2e-checks-qe-ocp:
+    if: github.repository == 'sebrandon1/bps-operator' && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    env:
+      KUBECONFIG: '/home/runner/.crc/machines/crc/kubeconfig'
+    steps:
+      - name: Checkout bps-operator
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install controller-gen
+        run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+
+      - name: Check if CRC_PULL_SECRET exists
+        env:
+          super_secret: ${{ secrets.CRC_PULL_SECRET }}
+        if: ${{ env.super_secret == '' }}
+        run: |
+          echo "CRC_PULL_SECRET is not set"
+          exit 1
+
+      - name: Build and save image
+        run: |
+          docker build -t bps-operator:e2e .
+          docker save bps-operator:e2e -o ${GITHUB_WORKSPACE}/bps-operator.tar
+
+      - name: Deploy OCP cluster
+        uses: palmsoftware/quick-ocp@fbe7eddbdbae7e1e983dcf8c83d593d7f2be6a1f # v0.0.30
+        with:
+          ocpPullSecret: $OCP_PULL_SECRET
+          bundleCache: true
+          desiredOCPVersion: 4.21
+          waitForOperatorsReady: true
+        env:
+          OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
+
+      - name: Push image to OpenShift internal registry
+        run: |
+          docker load -i ${GITHUB_WORKSPACE}/bps-operator.tar
+          KUBEADMIN_PASS=$(cat ~/.crc/machines/crc/kubeadmin-password)
+          oc login -u kubeadmin -p "$KUBEADMIN_PASS" https://api.crc.testing:6443 --insecure-skip-tls-verify
+          oc patch configs.imageregistry.operator.openshift.io/cluster --type merge -p '{"spec":{"defaultRoute":true}}'
+          sleep 10
+          REGISTRY=$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}')
+          docker login -u kubeadmin -p "$(oc whoami -t)" "$REGISTRY"
+          oc new-project bps-operator-system 2>/dev/null || true
+          REMOTE_IMG="$REGISTRY/bps-operator-system/bps-operator:e2e"
+          docker tag bps-operator:e2e "$REMOTE_IMG"
+          docker push "$REMOTE_IMG"
+          echo "INTERNAL_IMG=image-registry.openshift-image-registry.svc:5000/bps-operator-system/bps-operator:e2e" >> "$GITHUB_ENV"
+
+      - name: Deploy operator
+        run: |
+          make manifests
+          oc apply -f config/crd/bases/
+          oc apply -f config/rbac/
+          oc apply -f config/manager/
+          oc set image deployment/bps-operator-controller-manager manager=$INTERNAL_IMG -n bps-operator-system
+          oc patch deployment bps-operator-controller-manager -n bps-operator-system \
+            -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"Always"}]}}}}'
+
+      - name: Wait for operator to be ready
+        run: oc rollout status deployment/bps-operator-controller-manager -n bps-operator-system --timeout=120s
+
+      - name: Checkout checks-qe
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: redhat-best-practices-for-k8s/checks-qe
+          path: checks-qe
+
+      - name: Build checks-qe
+        run: go build -o checks-qe-bin ./cmd/checks-qe
+        working-directory: checks-qe
+
+      - name: Run checks-qe in operator mode
+        run: ./checks-qe/checks-qe-bin run --mode operator --skip-probe --parallel 4 --verbose

--- a/.github/workflows/e2e-checks-qe.yaml
+++ b/.github/workflows/e2e-checks-qe.yaml
@@ -1,0 +1,63 @@
+name: E2E checks-qe Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 4 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: read-all
+
+jobs:
+  e2e-checks-qe:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout bps-operator
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install controller-gen
+        run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+
+      - name: Create Kubernetes cluster
+        uses: palmsoftware/quick-k8s@378b23b1e3bdd8a40dd6bb6059d50886708ca687 # v0.0.60
+        with:
+          numControlPlaneNodes: 1
+          numWorkerNodes: 1
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and deploy operator
+        env:
+          IMG: quay.io/redhat-best-practices-for-k8s/bps-operator:e2e
+        run: |
+          make build-image IMG=$IMG
+          kind load docker-image $IMG --name kind
+          make deploy
+          kubectl set image deployment/bps-operator-controller-manager manager=$IMG -n bps-operator-system
+          kubectl patch deployment bps-operator-controller-manager -n bps-operator-system \
+            -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"IfNotPresent"}]}}}}'
+          kubectl rollout status deployment/bps-operator-controller-manager -n bps-operator-system --timeout=120s
+
+      - name: Checkout checks-qe
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: redhat-best-practices-for-k8s/checks-qe
+          path: checks-qe
+
+      - name: Build checks-qe
+        run: go build -o checks-qe-bin ./cmd/checks-qe
+        working-directory: checks-qe
+
+      - name: Run checks-qe in operator mode
+        run: ./checks-qe/checks-qe-bin run --mode operator --skip-ocp --skip-probe --parallel 4 --verbose

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -49,6 +49,12 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - ""
+  resources:
+  - pods/log
+  verbs:
+  - get
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/internal/controller/scanner_controller.go
+++ b/internal/controller/scanner_controller.go
@@ -56,6 +56,7 @@ var errProbesPending = fmt.Errorf("probe pods not yet running")
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch
 // +kubebuilder:rbac:groups=apps,resources=daemonsets;deployments;statefulsets,verbs=get;list;watch;create;update;delete
 // +kubebuilder:rbac:groups="",resources=pods/exec,verbs=create
+// +kubebuilder:rbac:groups="",resources=pods/log,verbs=get
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch
 // +kubebuilder:rbac:groups=storage.k8s.io,resources=storageclasses,verbs=get;list;watch


### PR DESCRIPTION
## Summary
- Add two new CI workflows that run checks-qe scenarios in operator mode
- `e2e-checks-qe.yaml`: KinD cluster, runs on all PRs and nightly
- `e2e-checks-qe-ocp.yaml`: OCP 4.21 (CRC), upstream-only

## How it works
1. Deploys the bps-operator to the cluster
2. Checks out and builds checks-qe
3. Runs `checks-qe run --mode operator` which creates BestPracticeScanner CRs per scenario and verifies BestPracticeResult CRs

## Dependency
Requires https://github.com/redhat-best-practices-for-k8s/checks-qe/pull/9 to be merged first (adds `--mode operator` to checks-qe).

## Test plan
- [ ] CI checks pass (existing workflows unaffected)
- [ ] New workflows will fail until checks-qe PR #9 is merged — expected