### PR TITLE
fix: use dot separator for result names and add godoc

### DIFF
--- a/internal/controller/scanner_controller.go
+++ b/internal/controller/scanner_controller.go
@@ -68,6 +68,7 @@ var errProbesPending = fmt.Errorf("probe pods not yet running")
 // +kubebuilder:rbac:groups=sriovnetwork.openshift.io,resources=sriovnetworks;sriovnetworknodepolicies,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
 
+// Reconcile handles a single BestPracticeScanner CR: discovers resources, runs checks, and upserts results.
 func (r *ScannerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
@@ -272,7 +273,7 @@ func (r *ScannerReconciler) runChecks(ctx context.Context, scannerCR *bpsv1alpha
 			summary.Skipped++
 		}
 
-		resultName := fmt.Sprintf("%s-%s", scannerCR.Name, check.Name)
+		resultName := fmt.Sprintf("%s.%s", scannerCR.Name, check.Name)
 		resultNames[resultName] = true
 
 		r.upsertResult(ctx, scannerCR, check, checkResult, resultName, now)

--- a/internal/probe/daemonset.go
+++ b/internal/probe/daemonset.go
@@ -103,6 +103,7 @@ func DeleteDaemonSet(ctx context.Context, c client.Client, namespace string) err
 	return err
 }
 
+// MapProbePods returns a map of node name to running probe pod for the given namespace.
 func MapProbePods(ctx context.Context, c client.Client, namespace string) (map[string]*corev1.Pod, error) {
 	var podList corev1.PodList
 	if err := c.List(ctx, &podList,

--- a/internal/probe/exec.go
+++ b/internal/probe/exec.go
@@ -36,10 +36,12 @@ func NewExecutor(config *rest.Config, timeout time.Duration) (*Executor, error) 
 	return &Executor{clientset: cs, config: config, timeout: timeout}, nil
 }
 
+// ExecCommand runs a command in the default probe container via the pods/exec API.
 func (e *Executor) ExecCommand(ctx context.Context, pod *corev1.Pod, command string) (string, string, error) {
 	return e.ExecCommandInContainer(ctx, pod, ProbeName, command)
 }
 
+// ExecCommandInContainer runs a command in the named container via the pods/exec API.
 func (e *Executor) ExecCommandInContainer(ctx context.Context, pod *corev1.Pod, containerName, command string) (string, string, error) {
 	ctx, cancel := context.WithTimeout(ctx, e.timeout)
 	defer cancel()


### PR DESCRIPTION
## Summary
- Use `.` separator in BestPracticeResult names (`scanner.check-name` instead of `scanner-check-name`) to prevent collisions when scanner and check names share hyphenated prefixes
- Add godoc to exported symbols: `MapProbePods`, `ExecCommand`, `ExecCommandInContainer`, `Reconcile`

Closes #28, closes #30

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `make lint` — 0 issues
- [ ] CI checks pass