### PR TITLE
fix: deploy operator in-cluster and improve quick start workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TEST_NAMESPACE ?= bps-test
 KIND_CLUSTER_NAME ?= kind
 
 # Use oc if available, fall back to kubectl
-KUBECTL ?= $(shell command -v oc 2>/dev/null || echo kubectl)
+KUBECTL ?= $(shell command -v oc >/dev/null 2>&1 && echo oc || echo kubectl)
 
 .PHONY: build
 build:
@@ -113,7 +113,7 @@ uninstall: ## Remove CRDs from the cluster
 	$(KUBECTL) delete --ignore-not-found -f config/crd/bases/
 
 .PHONY: deploy
-deploy: manifests ## Deploy the operator (CRDs + RBAC + manager Deployment)
+deploy: manifests _ensure-operator-ns ## Deploy the operator (CRDs + RBAC + manager Deployment)
 	$(KUBECTL) apply -f config/crd/bases/
 	$(KUBECTL) apply -f config/rbac/
 	$(KUBECTL) apply -f config/manager/
@@ -124,13 +124,20 @@ undeploy: ## Remove the operator from the cluster
 	$(KUBECTL) delete --ignore-not-found -f config/rbac/
 	$(KUBECTL) delete --ignore-not-found -f config/crd/bases/
 
-##@ Local Development
+##@ Helpers
 
-.PHONY: run
-run: install ## Run the operator locally against the current cluster
-	go run ./cmd/ --operator-namespace=$(OPERATOR_NAMESPACE)
-
-##@ Test Workloads
+# Helper: ensure the operator namespace exists with required privileges for the probe DaemonSet
+.PHONY: _ensure-operator-ns
+_ensure-operator-ns:
+	@$(KUBECTL) create namespace $(OPERATOR_NAMESPACE) --dry-run=client -o yaml | $(KUBECTL) apply -f - 2>/dev/null
+	@if $(KUBECTL) api-resources --api-group=security.openshift.io 2>/dev/null | grep -q securitycontextconstraints; then \
+		$(KUBECTL) label namespace $(OPERATOR_NAMESPACE) \
+			security.openshift.io/scc.podSecurityLabelSync=false \
+			pod-security.kubernetes.io/enforce=privileged \
+			pod-security.kubernetes.io/warn=privileged \
+			pod-security.kubernetes.io/audit=privileged --overwrite 2>/dev/null; \
+		$(KUBECTL) adm policy add-scc-to-user privileged -z default -n $(OPERATOR_NAMESPACE) 2>/dev/null || true; \
+	fi
 
 # Helper: deploy test workloads and prepare namespace (no scanner CR)
 .PHONY: _deploy-test-workloads
@@ -139,64 +146,70 @@ _deploy-test-workloads: install
 	@$(KUBECTL) delete --ignore-not-found -f config/samples/scanner_bps_test.yaml 2>/dev/null || true
 	@$(KUBECTL) delete --ignore-not-found -f config/samples/scanner_bps_test_periodic.yaml 2>/dev/null || true
 	$(KUBECTL) apply -f config/samples/test-workloads.yaml
-	@if $(KUBECTL) api-resources 2>/dev/null | grep -q securitycontextconstraints; then \
+	@if $(KUBECTL) api-resources --api-group=security.openshift.io 2>/dev/null | grep -q securitycontextconstraints; then \
 		echo "OpenShift detected — granting privileged SCC to default SA in $(TEST_NAMESPACE)"; \
 		$(KUBECTL) adm policy add-scc-to-user privileged -z default -n $(TEST_NAMESPACE); \
 	fi
 	@echo "Waiting for namespace to be ready..."
 	@$(KUBECTL) wait --for=jsonpath='{.status.phase}'=Active namespace/$(TEST_NAMESPACE) --timeout=10s
 
+##@ Scanning
+
 .PHONY: deploy-test
 deploy-test: _deploy-test-workloads ## Deploy test workloads only (no scanner CR)
 	@echo ""
-	@echo "Test workloads deployed to $(TEST_NAMESPACE)."
-	@echo "Use 'make deploy-scan' or 'make deploy-periodic-scan' to add a scanner."
+	@echo "=== Test Workloads Deployed ==="
+	@echo "  Namespace:  $(TEST_NAMESPACE)"
+	@echo "  Pods:       good-pod (compliant), bad-pod (non-compliant)"
+	@echo "  Services:   good-clusterip-svc, bad-nodeport-svc"
+	@echo ""
+	@echo "Next steps:"
+	@echo "  1. Run a scan:    make deploy-scan  OR  make deploy-periodic-scan"
+	@echo "  2. View results:  make show-results"
 
 .PHONY: deploy-scan
-deploy-scan: _deploy-test-workloads ## Deploy test workloads + one-shot scanner into bps-test namespace
+deploy-scan: deploy _deploy-test-workloads ## Deploy operator, run one-shot scan, show results
+	@echo "Waiting for operator to be ready..."
+	@$(KUBECTL) rollout status deployment/bps-operator-controller-manager -n $(OPERATOR_NAMESPACE) --timeout=120s
 	$(KUBECTL) apply -f config/samples/scanner_bps_test.yaml
 	@echo ""
-	@echo "One-shot scanner deployed to $(TEST_NAMESPACE)."
-	@echo "Run 'make run' in another terminal to start the operator."
-	@echo "Then: $(KUBECTL) get bestpracticeresults -n $(TEST_NAMESPACE)"
+	@echo "=== One-Shot Scan ==="
+	@echo "  Namespace:  $(TEST_NAMESPACE)"
+	@echo ""
+	@echo "Waiting for scan to complete..."
+	@for i in $$(seq 1 60); do \
+		PHASE=$$($(KUBECTL) get bestpracticescanners test-scanner -n $(TEST_NAMESPACE) -o jsonpath='{.status.phase}' 2>/dev/null); \
+		if [ "$$PHASE" = "Completed" ]; then break; fi; \
+		if [ $$i -eq 60 ]; then echo "Timed out waiting for scan (phase: $$PHASE)"; fi; \
+		sleep 2; \
+	done
+	@echo ""
+	@$(MAKE) show-results
 
 .PHONY: deploy-periodic-scan
-deploy-periodic-scan: _deploy-test-workloads ## Deploy test workloads + periodic scanner (5m interval) into bps-test namespace
+deploy-periodic-scan: deploy _deploy-test-workloads ## Deploy operator, start periodic scan (5m interval)
+	@echo "Waiting for operator to be ready..."
+	@$(KUBECTL) rollout status deployment/bps-operator-controller-manager -n $(OPERATOR_NAMESPACE) --timeout=120s
 	$(KUBECTL) apply -f config/samples/scanner_bps_test_periodic.yaml
 	@echo ""
-	@echo "Periodic scanner deployed to $(TEST_NAMESPACE) (interval: 5m)."
-	@echo "Run 'make run' in another terminal to start the operator."
-	@echo "Then: $(KUBECTL) get bestpracticeresults -n $(TEST_NAMESPACE)"
+	@echo "=== Periodic Scan Started ==="
+	@echo "  Namespace:  $(TEST_NAMESPACE)"
+	@echo "  Interval:   every 5m"
+	@echo ""
+	@echo "View results:  make show-results"
+	@echo "View failures: make show-failures"
 
 .PHONY: undeploy-test
 undeploy-test: ## Remove test workloads, scanner, and bps-test namespace
 	$(KUBECTL) delete --ignore-not-found -f config/samples/scanner_bps_test_periodic.yaml
 	$(KUBECTL) delete --ignore-not-found -f config/samples/scanner_bps_test.yaml
 	$(KUBECTL) delete --ignore-not-found -f config/samples/test-workloads.yaml
-	@if $(KUBECTL) api-resources 2>/dev/null | grep -q securitycontextconstraints; then \
+	@if $(KUBECTL) api-resources --api-group=security.openshift.io 2>/dev/null | grep -q securitycontextconstraints; then \
 		$(KUBECTL) adm policy remove-scc-from-user privileged -z default -n $(TEST_NAMESPACE) 2>/dev/null || true; \
 	fi
 
 .PHONY: scan
-scan: install ## One-shot: deploy test workloads, run operator, show results, then stop
-	@$(MAKE) deploy-scan
-	@echo ""
-	@echo "Starting operator..."
-	@go run ./cmd/ --operator-namespace=$(OPERATOR_NAMESPACE) &>/tmp/bps-operator.log & \
-		PID=$$!; \
-		echo "Operator PID: $$PID"; \
-		echo "Waiting for scan to complete..."; \
-		for i in $$(seq 1 30); do \
-			PHASE=$$($(KUBECTL) get bestpracticescanners test-scanner -n $(TEST_NAMESPACE) -o jsonpath='{.status.phase}' 2>/dev/null); \
-			if [ "$$PHASE" = "Completed" ]; then break; fi; \
-			sleep 1; \
-		done; \
-		echo ""; \
-		$(MAKE) show-results; \
-		kill $$PID 2>/dev/null; \
-		wait $$PID 2>/dev/null; \
-		echo ""; \
-		echo "Operator stopped. Full logs at /tmp/bps-operator.log"
+scan: deploy-scan ## Alias for deploy-scan
 
 .PHONY: show-results
 show-results: ## Show scan results from the cluster

--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@ bps-operator watches for `BestPracticeScanner` custom resources and runs a confi
 
 ## Quick Start
 
+**Prerequisites**: A running Kubernetes or OpenShift cluster with `kubectl`/`oc` configured.
+
 ```bash
-# Install CRDs
-make install
+# One-shot scan — deploys operator in-cluster, runs all checks, shows results
+make deploy-scan
 
-# Deploy test workloads and a scanner CR
-make deploy-test
+# Or for continuous scanning every 5 minutes
+make deploy-periodic-scan
 
-# Run the operator locally (in another terminal)
-make run
-
-# View results
+# View results anytime
 make show-results
-
-# View failures only
 make show-failures
+
+# Clean up everything
+make clean
 ```
 
 ## CRD API
@@ -58,17 +58,19 @@ Records the outcome of a single check.
 
 ## Checks Summary
 
-57 checks across 7 categories:
+105 checks across 9 categories (provided by [redhat-best-practices-for-k8s/checks](https://github.com/redhat-best-practices-for-k8s/checks)):
 
-| Category | Count | README |
-|---|---|---|
-| Access Control | 24 | [internal/checks/accesscontrol/](internal/checks/accesscontrol/README.md) |
-| Lifecycle | 14 | [internal/checks/lifecycle/](internal/checks/lifecycle/README.md) |
-| Platform | 7 | [internal/checks/platform/](internal/checks/platform/README.md) |
-| Networking | 4 | [internal/checks/networking/](internal/checks/networking/README.md) |
-| Observability | 3 | [internal/checks/observability/](internal/checks/observability/README.md) |
-| Performance | 3 | [internal/checks/performance/](internal/checks/performance/README.md) |
-| Manageability | 2 | [internal/checks/manageability/](internal/checks/manageability/README.md) |
+| Category | Count |
+|---|---|
+| Access Control | 28 |
+| Lifecycle | 19 |
+| Platform Alteration | 15 |
+| Operator | 12 |
+| Networking | 11 |
+| Performance | 9 |
+| Observability | 5 |
+| Affiliated Certification | 4 |
+| Manageability | 2 |
 
 ## Usage
 
@@ -78,12 +80,11 @@ Records the outcome of a single check.
 | `make test` | Run unit tests with coverage |
 | `make lint` | Run golangci-lint |
 | `make install` | Install CRDs onto the cluster |
-| `make run` | Run the operator locally against the current cluster |
 | `make deploy` | Deploy operator to the cluster (CRDs + RBAC + manager) |
 | `make deploy-test` | Deploy test workloads only (no scanner) into `bps-test` namespace |
-| `make deploy-scan` | Deploy test workloads and one-shot scanner into `bps-test` namespace |
-| `make deploy-periodic-scan` | Deploy test workloads and periodic scanner (5m interval) into `bps-test` namespace |
-| `make scan` | One-shot: deploy test workloads, run operator, show results, stop |
+| `make deploy-scan` | Deploy operator, run one-shot scan, show results |
+| `make deploy-periodic-scan` | Deploy operator, start periodic scan (5m interval) |
+| `make scan` | Alias for `deploy-scan` |
 | `make show-results` | Show scan results from the cluster |
 | `make show-failures` | Show details for all non-compliant results |
 | `make show-scan-yaml` | Print the one-shot scanner CR YAML |
@@ -118,7 +119,7 @@ spec:
 - **targetNamespace**: Which namespace to scan. Defaults to the CR's own namespace.
 - **labelSelector**: Filter pods by labels. Omit to scan all pods in the namespace.
 - **scanInterval**: How often to re-scan (e.g., "5m", "1h30m", "10s"). Must be a valid Go duration string. Omit for a one-shot scan. The API validates this format at admission time, rejecting invalid durations like "5mins" or "1 hour".
-- **checks**: Run only specific checks by name. Omit to run all 57 checks.
+- **checks**: Run only specific checks by name. Omit to run all checks.
 - **suspend**: Set to `true` to pause periodic scanning.
 
 ## Architecture
@@ -129,14 +130,7 @@ api/v1alpha1/            CRD type definitions (BestPracticeScanner, BestPractice
 internal/
   controller/            Reconciler for BestPracticeScanner CRs
   scanner/               Orchestrates check execution and result creation
-  checks/                Check registry and per-category implementations
-    accesscontrol/       24 access-control checks
-    lifecycle/           14 lifecycle checks
-    networking/          4 networking checks
-    observability/       3 observability checks
-    performance/         3 performance checks
-    platform/            7 platform checks
-    manageability/       2 manageability checks
+  certification/         Red Hat container certification validation
   probe/                 Probe DaemonSet for exec-based checks
 config/
   crd/bases/             Generated CRD manifests
@@ -144,6 +138,8 @@ config/
   manager/               Operator Deployment manifest
   samples/               Example CRs and test workloads
 ```
+
+Check implementations are provided by the external [redhat-best-practices-for-k8s/checks](https://github.com/redhat-best-practices-for-k8s/checks) library.
 
 ## Security Model
 
@@ -183,22 +179,6 @@ The probe runs with elevated privileges to enable checks such as:
 Checks that only inspect Kubernetes API objects (pods, services, RBAC, etc.) run directly in the operator without elevated privileges.
 
 For detailed security documentation, see [internal/probe/daemonset.go](internal/probe/daemonset.go).
-
-## Building and Running
-
-```bash
-# Build locally
-make build
-
-# Run against current kubeconfig
-make run
-
-# Build container image
-make build-image IMG=my-registry/bps-operator:dev
-
-# Deploy to cluster
-make deploy IMG=my-registry/bps-operator:dev
-```
 
 ## Certsuite Alignment
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/scale"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -92,6 +93,14 @@ func run(opts options, cfg *rest.Config) error {
 			BindAddress: opts.metricsAddr,
 		},
 		HealthProbeBindAddress: opts.probeAddr,
+		Client: client.Options{
+			Cache: &client.CacheOptions{
+				// PackageManifest is a virtual resource from OLM package-server that does not support Watch.
+				DisableFor: []client.Object{
+					&olmpackagev1.PackageManifest{},
+				},
+			},
+		},
 	})
 	if err != nil {
 		return fmt.Errorf("creating manager: %w", err)


### PR DESCRIPTION
## Summary

- Remove `make run` — operator always runs in-cluster as a Deployment, eliminating the need for local processes or separate terminal sessions
- `make deploy-scan` and `make deploy-periodic-scan` now handle the full lifecycle: deploy operator, deploy test workloads, apply scanner CRs, wait for results, and display them
- `make deploy` auto-creates the operator namespace with SCC/PodSecurity privileges on OpenShift for the probe DaemonSet
- Disable controller-runtime cache for OLM PackageManifest (virtual resource that does not support Watch), eliminating noisy error log spam
- Fix KUBECTL resolution to output `oc` instead of full Homebrew path
- Scope `api-resources` calls to `security.openshift.io` API group for faster SCC detection
- Use idempotent `create --dry-run=client | apply` for namespace creation
- Improve deploy target output with structured status and next steps
- Update README Quick Start and Usage table to reflect the simplified workflow

## Test plan

- [ ] `make deploy-scan` on a clean cluster: deploys operator, runs one-shot scan, shows results
- [ ] `make deploy-periodic-scan` on a clean cluster: deploys operator, starts periodic scanning
- [ ] `make show-results` and `make show-failures` display correct output
- [ ] `make clean` removes all resources
- [ ] Verify no `go run` or local operator processes are used anywhere
- [ ] Verify no PackageManifest watch errors in operator logs