### PR TITLE
ci: use prebuilt checks-qe container image for e2e tests

### DIFF
--- a/.github/workflows/e2e-checks-qe-ocp.yaml
+++ b/.github/workflows/e2e-checks-qe-ocp.yaml
@@ -21,6 +21,7 @@ jobs:
     timeout-minutes: 120
     env:
       KUBECONFIG: '/home/runner/.crc/machines/crc/kubeconfig'
+      CHECKS_QE_IMAGE: quay.io/redhat-best-practices-for-k8s/checks-qe:unstable
     steps:
       - name: Checkout bps-operator
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -84,15 +85,11 @@ jobs:
       - name: Wait for operator to be ready
         run: oc rollout status deployment/bps-operator-controller-manager -n bps-operator-system --timeout=120s
 
-      - name: Checkout checks-qe
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: redhat-best-practices-for-k8s/checks-qe
-          path: checks-qe
-
-      - name: Build checks-qe
-        run: go build -o checks-qe-bin ./cmd/checks-qe
-        working-directory: checks-qe
-
       - name: Run checks-qe in operator mode
-        run: ./checks-qe/checks-qe-bin run --mode operator --skip-probe --parallel 4 --verbose
+        run: |
+          docker run --rm \
+            --network host \
+            -v $KUBECONFIG:/tmp/kubeconfig:ro \
+            -e KUBECONFIG=/tmp/kubeconfig \
+            $CHECKS_QE_IMAGE \
+            run --mode operator --skip-probe --parallel 4 --verbose

--- a/.github/workflows/e2e-checks-qe.yaml
+++ b/.github/workflows/e2e-checks-qe.yaml
@@ -18,6 +18,8 @@ jobs:
   e2e-checks-qe:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    env:
+      CHECKS_QE_IMAGE: quay.io/redhat-best-practices-for-k8s/checks-qe:unstable
     steps:
       - name: Checkout bps-operator
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -49,15 +51,11 @@ jobs:
             -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"IfNotPresent"}]}}}}'
           kubectl rollout status deployment/bps-operator-controller-manager -n bps-operator-system --timeout=120s
 
-      - name: Checkout checks-qe
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          repository: redhat-best-practices-for-k8s/checks-qe
-          path: checks-qe
-
-      - name: Build checks-qe
-        run: go build -o checks-qe-bin ./cmd/checks-qe
-        working-directory: checks-qe
-
       - name: Run checks-qe in operator mode
-        run: ./checks-qe/checks-qe-bin run --mode operator --skip-ocp --skip-probe --parallel 4 --verbose
+        run: |
+          docker run --rm \
+            --network host \
+            -v $HOME/.kube/config:/tmp/kubeconfig:ro \
+            -e KUBECONFIG=/tmp/kubeconfig \
+            $CHECKS_QE_IMAGE \
+            run --mode operator --skip-ocp --skip-probe --parallel 4 --verbose


### PR DESCRIPTION
## Summary
- Replace clone-and-build steps in both checks-qe e2e workflows with `docker run` using the prebuilt `quay.io/redhat-best-practices-for-k8s/checks-qe:unstable` image
- Eliminates the need to checkout the checks-qe repo and compile the Go binary during CI
- Uses `--network host` and kubeconfig volume mount for cluster connectivity

## Test plan
- [ ] `E2E checks-qe Tests` workflow passes (Kind cluster)
- [ ] `E2E checks-qe OCP Tests` workflow passes (OCP/CRC cluster)