### PR TITLE
docs: add networking-only and label selector scanner samples

### DIFF
--- a/config/samples/scanner_label_selector.yaml
+++ b/config/samples/scanner_label_selector.yaml
@@ -1,0 +1,10 @@
+apiVersion: bps.openshift.io/v1alpha1
+kind: BestPracticeScanner
+metadata:
+  name: targeted-scanner
+  namespace: default
+spec:
+  targetNamespace: default
+  labelSelector:
+    matchLabels:
+      app: my-workload

--- a/config/samples/scanner_networking.yaml
+++ b/config/samples/scanner_networking.yaml
@@ -1,0 +1,15 @@
+apiVersion: bps.openshift.io/v1alpha1
+kind: BestPracticeScanner
+metadata:
+  name: networking-scanner
+  namespace: default
+spec:
+  targetNamespace: default
+  checks:
+    - networking-dual-stack-service
+    - networking-icmpv4-connectivity
+    - networking-icmpv6-connectivity
+    - networking-network-policy-deny-all
+    - networking-ocp-reserved-ports-usage
+    - networking-reserved-partner-ports
+    - networking-undeclared-container-ports-usage


### PR DESCRIPTION
## Summary
- Add `scanner_networking.yaml` sample that runs only the 7 non-telco networking checks (dual-stack, ICMP connectivity, network policies, reserved ports, undeclared ports)
- Add `scanner_label_selector.yaml` sample that scans only pods matching a specific label (`app: my-workload`)

## Test plan
- [ ] Verify YAML is valid and matches the CRD schema
- [ ] CI passes