### PR TITLE
test: increase coverage from 49% to 65%

### DIFF
--- a/internal/controller/scanner_controller_test.go
+++ b/internal/controller/scanner_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"testing"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -42,11 +43,15 @@ func newScheme() *runtime.Scheme {
 	return s
 }
 
+func newReconciler(c client.Client, s *runtime.Scheme) *ScannerReconciler {
+	return &ScannerReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
+}
+
 func TestReconcile_ScannerNotFound(t *testing.T) {
 	s := newScheme()
 	c := fake.NewClientBuilder().WithScheme(s).Build()
 
-	r := &ScannerReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
+	r := newReconciler(c, s)
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "missing", Namespace: "test"},
 	})
@@ -70,7 +75,7 @@ func TestReconcile_Suspend(t *testing.T) {
 		WithStatusSubresource(scanner).
 		Build()
 
-	r := &ScannerReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
+	r := newReconciler(c, s)
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "test-scanner", Namespace: "test-ns"},
 	})
@@ -111,7 +116,7 @@ func TestReconcile_FullScan(t *testing.T) {
 		WithStatusSubresource(scanner).
 		Build()
 
-	r := &ScannerReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
+	r := newReconciler(c, s)
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "scanner", Namespace: "ns"},
 	})
@@ -174,7 +179,7 @@ func TestReconcile_NonCompliant(t *testing.T) {
 		WithStatusSubresource(scanner).
 		Build()
 
-	r := &ScannerReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
+	r := newReconciler(c, s)
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "scanner", Namespace: "ns"},
 	})
@@ -213,7 +218,7 @@ func TestReconcile_WithScanInterval(t *testing.T) {
 		WithStatusSubresource(scanner).
 		Build()
 
-	r := &ScannerReconciler{Client: c, Scheme: s, Recorder: record.NewFakeRecorder(10)}
+	r := newReconciler(c, s)
 	result, err := r.Reconcile(context.Background(), ctrl.Request{
 		NamespacedName: types.NamespacedName{Name: "scanner", Namespace: "ns"},
 	})
@@ -222,5 +227,333 @@ func TestReconcile_WithScanInterval(t *testing.T) {
 	}
 	if result.RequeueAfter == 0 {
 		t.Error("expected RequeueAfter to be set")
+	}
+}
+
+func TestReconcile_InvalidScanInterval(t *testing.T) {
+	s := newScheme()
+
+	scanner := &bpsv1alpha1.BestPracticeScanner{
+		ObjectMeta: metav1.ObjectMeta{Name: "scanner", Namespace: "ns"},
+		Spec: bpsv1alpha1.BestPracticeScannerSpec{
+			ScanInterval: "invalid-duration",
+			Checks:       []string{"access-control-pod-host-network"},
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "ns"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c1", Image: "img"}}},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(scanner, pod).
+		WithStatusSubresource(scanner).
+		Build()
+
+	r := newReconciler(c, s)
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "scanner", Namespace: "ns"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Invalid interval treated as one-shot, no requeue
+	if result.RequeueAfter != 0 {
+		t.Error("expected no requeue for invalid scanInterval (treated as one-shot)")
+	}
+}
+
+func TestReconcile_EnforceUniqueness(t *testing.T) {
+	s := newScheme()
+
+	earlier := metav1.NewTime(time.Now().Add(-1 * time.Hour))
+	later := metav1.NewTime(time.Now())
+
+	existingScanner := &bpsv1alpha1.BestPracticeScanner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "existing-scanner",
+			Namespace:         "ns",
+			CreationTimestamp: earlier,
+		},
+		Spec: bpsv1alpha1.BestPracticeScannerSpec{
+			Checks: []string{"access-control-pod-host-network"},
+		},
+	}
+
+	newScanner := &bpsv1alpha1.BestPracticeScanner{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "new-scanner",
+			Namespace:         "ns",
+			CreationTimestamp: later,
+		},
+		Spec: bpsv1alpha1.BestPracticeScannerSpec{
+			Checks: []string{"access-control-pod-host-network"},
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(existingScanner, newScanner).
+		WithStatusSubresource(existingScanner, newScanner).
+		Build()
+
+	r := newReconciler(c, s)
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "new-scanner", Namespace: "ns"},
+	})
+	if err == nil {
+		t.Fatal("expected error for duplicate scanner")
+	}
+
+	// Verify the newer scanner was set to Error phase
+	var updated bpsv1alpha1.BestPracticeScanner
+	_ = c.Get(context.Background(), types.NamespacedName{Name: "new-scanner", Namespace: "ns"}, &updated)
+	if updated.Status.Phase != bpsv1alpha1.PhaseError {
+		t.Errorf("expected Error phase, got %s", updated.Status.Phase)
+	}
+}
+
+func TestReconcile_DeleteStaleResults(t *testing.T) {
+	s := newScheme()
+
+	scanner := &bpsv1alpha1.BestPracticeScanner{
+		ObjectMeta: metav1.ObjectMeta{Name: "scanner", Namespace: "ns"},
+		Spec: bpsv1alpha1.BestPracticeScannerSpec{
+			Checks: []string{"access-control-pod-host-network"},
+		},
+	}
+
+	// Pre-existing stale result from a check that is no longer in the scan
+	staleResult := &bpsv1alpha1.BestPracticeResult{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "scanner.old-check",
+			Namespace: "ns",
+		},
+		Spec: bpsv1alpha1.BestPracticeResultSpec{
+			ScannerRef: "scanner",
+			CheckName:  "old-check",
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "ns"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c1", Image: "img"}}},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(scanner, staleResult, pod).
+		WithStatusSubresource(scanner).
+		WithIndex(&bpsv1alpha1.BestPracticeResult{}, "spec.scannerRef", func(obj client.Object) []string {
+			result := obj.(*bpsv1alpha1.BestPracticeResult)
+			return []string{result.Spec.ScannerRef}
+		}).
+		Build()
+
+	r := newReconciler(c, s)
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "scanner", Namespace: "ns"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify the stale result was deleted
+	var resultList bpsv1alpha1.BestPracticeResultList
+	_ = c.List(context.Background(), &resultList, client.InNamespace("ns"))
+
+	for _, r := range resultList.Items {
+		if r.Name == "scanner.old-check" {
+			t.Error("stale result scanner.old-check should have been deleted")
+		}
+	}
+
+	// Verify the current check result exists
+	found := false
+	for _, r := range resultList.Items {
+		if r.Spec.CheckName == "access-control-pod-host-network" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected result for access-control-pod-host-network to exist")
+	}
+}
+
+func TestReconcile_CompletedOneShotSkipsRescan(t *testing.T) {
+	s := newScheme()
+
+	now := metav1.Now()
+	scanner := &bpsv1alpha1.BestPracticeScanner{
+		ObjectMeta: metav1.ObjectMeta{Name: "scanner", Namespace: "ns"},
+		Spec: bpsv1alpha1.BestPracticeScannerSpec{
+			Checks: []string{"access-control-pod-host-network"},
+		},
+		Status: bpsv1alpha1.BestPracticeScannerStatus{
+			Phase:        bpsv1alpha1.PhaseCompleted,
+			LastScanTime: &now,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(scanner).
+		WithStatusSubresource(scanner).
+		Build()
+
+	r := newReconciler(c, s)
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "scanner", Namespace: "ns"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Error("expected no requeue for completed one-shot scan")
+	}
+}
+
+func TestReconcile_CompletedPeriodicRequeuesWhenNotDue(t *testing.T) {
+	s := newScheme()
+
+	now := metav1.Now()
+	scanner := &bpsv1alpha1.BestPracticeScanner{
+		ObjectMeta: metav1.ObjectMeta{Name: "scanner", Namespace: "ns"},
+		Spec: bpsv1alpha1.BestPracticeScannerSpec{
+			ScanInterval: "1h",
+			Checks:       []string{"access-control-pod-host-network"},
+		},
+		Status: bpsv1alpha1.BestPracticeScannerStatus{
+			Phase:        bpsv1alpha1.PhaseCompleted,
+			LastScanTime: &now,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(scanner).
+		WithStatusSubresource(scanner).
+		Build()
+
+	r := newReconciler(c, s)
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "scanner", Namespace: "ns"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Error("expected requeue for periodic scan not yet due")
+	}
+	if result.RequeueAfter > 1*time.Hour {
+		t.Errorf("expected requeue within 1h, got %v", result.RequeueAfter)
+	}
+}
+
+func TestReconcile_CatalogURL(t *testing.T) {
+	s := newScheme()
+
+	scanner := &bpsv1alpha1.BestPracticeScanner{
+		ObjectMeta: metav1.ObjectMeta{Name: "scanner", Namespace: "ns"},
+		Spec: bpsv1alpha1.BestPracticeScannerSpec{
+			Checks: []string{"access-control-pod-host-network"},
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "ns"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c1", Image: "img"}}},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(scanner, pod).
+		WithStatusSubresource(scanner).
+		Build()
+
+	r := &ScannerReconciler{
+		Client:         c,
+		Scheme:         s,
+		Recorder:       record.NewFakeRecorder(10),
+		CatalogURLBase: "https://example.com/CATALOG.md",
+	}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "scanner", Namespace: "ns"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var resultList bpsv1alpha1.BestPracticeResultList
+	_ = c.List(context.Background(), &resultList, client.InNamespace("ns"))
+	if len(resultList.Items) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(resultList.Items))
+	}
+
+	result := resultList.Items[0]
+	if result.Spec.CatalogURL == "" {
+		t.Error("expected CatalogURL to be set when CatalogURLBase is configured")
+	}
+}
+
+func TestReconcile_DefaultTargetNamespace(t *testing.T) {
+	s := newScheme()
+
+	scanner := &bpsv1alpha1.BestPracticeScanner{
+		ObjectMeta: metav1.ObjectMeta{Name: "scanner", Namespace: "my-ns"},
+		Spec: bpsv1alpha1.BestPracticeScannerSpec{
+			Checks: []string{"access-control-pod-host-network"},
+		},
+	}
+
+	// Pod in scanner's namespace (should be discovered when targetNamespace is empty)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "my-ns"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c1", Image: "img"}}},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(scanner, pod).
+		WithStatusSubresource(scanner).
+		Build()
+
+	r := newReconciler(c, s)
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "scanner", Namespace: "my-ns"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify results were created in scanner's namespace
+	var resultList bpsv1alpha1.BestPracticeResultList
+	_ = c.List(context.Background(), &resultList, client.InNamespace("my-ns"))
+	if len(resultList.Items) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(resultList.Items))
+	}
+}
+
+func TestReconcile_SuspendAlreadyIdle(t *testing.T) {
+	s := newScheme()
+
+	scanner := &bpsv1alpha1.BestPracticeScanner{
+		ObjectMeta: metav1.ObjectMeta{Name: "scanner", Namespace: "ns"},
+		Spec:       bpsv1alpha1.BestPracticeScannerSpec{Suspend: true},
+		Status: bpsv1alpha1.BestPracticeScannerStatus{
+			Phase: bpsv1alpha1.PhaseIdle,
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(scanner).
+		WithStatusSubresource(scanner).
+		Build()
+
+	r := newReconciler(c, s)
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "scanner", Namespace: "ns"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Error("expected no requeue for suspended scanner")
 	}
 }

--- a/internal/probe/probe_test.go
+++ b/internal/probe/probe_test.go
@@ -14,12 +14,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-func TestEnsureDaemonSet_Create(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = appsv1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = appsv1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
 
-	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	return s
+}
+
+func TestEnsureDaemonSet_Create(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(newScheme()).Build()
 
 	err := EnsureDaemonSet(context.Background(), client, "test-ns", ProbeImage)
 	if err != nil {
@@ -41,11 +45,7 @@ func TestEnsureDaemonSet_Create(t *testing.T) {
 }
 
 func TestEnsureDaemonSet_CustomImage(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = appsv1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-
-	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	client := fake.NewClientBuilder().WithScheme(newScheme()).Build()
 
 	customImage := "my-registry.io/custom-probe:v1.0.0"
 	err := EnsureDaemonSet(context.Background(), client, "test-ns", customImage)
@@ -65,11 +65,7 @@ func TestEnsureDaemonSet_CustomImage(t *testing.T) {
 }
 
 func TestEnsureDaemonSet_EmptyImageUsesDefault(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = appsv1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-
-	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	client := fake.NewClientBuilder().WithScheme(newScheme()).Build()
 
 	err := EnsureDaemonSet(context.Background(), client, "test-ns", "")
 	if err != nil {
@@ -88,11 +84,7 @@ func TestEnsureDaemonSet_EmptyImageUsesDefault(t *testing.T) {
 }
 
 func TestEnsureDaemonSet_NoUpdateWhenUnchanged(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = appsv1.AddToScheme(scheme)
-	_ = corev1.AddToScheme(scheme)
-
-	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	client := fake.NewClientBuilder().WithScheme(newScheme()).Build()
 
 	// Create initial DaemonSet
 	err := EnsureDaemonSet(context.Background(), client, "test-ns", ProbeImage)
@@ -127,9 +119,6 @@ func TestEnsureDaemonSet_NoUpdateWhenUnchanged(t *testing.T) {
 }
 
 func TestMapProbePods(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "probe-node1",
@@ -140,7 +129,7 @@ func TestMapProbePods(t *testing.T) {
 		Status: corev1.PodStatus{Phase: corev1.PodRunning},
 	}
 
-	client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pod).Build()
+	client := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(pod).Build()
 
 	probeMap, err := MapProbePods(context.Background(), client, "test-ns")
 	if err != nil {
@@ -151,6 +140,117 @@ func TestMapProbePods(t *testing.T) {
 	}
 	if probeMap["node1"] == nil {
 		t.Error("expected probe pod for node1")
+	}
+}
+
+func TestDeleteDaemonSet(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+
+	// Create DaemonSet first
+	err := EnsureDaemonSet(context.Background(), client, "test-ns", ProbeImage)
+	if err != nil {
+		t.Fatalf("unexpected error creating DaemonSet: %v", err)
+	}
+
+	// Delete it
+	err = DeleteDaemonSet(context.Background(), client, "test-ns")
+	if err != nil {
+		t.Fatalf("unexpected error deleting DaemonSet: %v", err)
+	}
+
+	// Verify it's gone
+	var ds appsv1.DaemonSet
+	err = client.Get(context.Background(), types.NamespacedName{Name: ProbeName, Namespace: "test-ns"}, &ds)
+	if err == nil {
+		t.Error("expected DaemonSet to be deleted")
+	}
+}
+
+func TestDeleteDaemonSet_NotFound(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+
+	// Deleting non-existent DaemonSet should succeed (not found is not an error)
+	err := DeleteDaemonSet(context.Background(), client, "test-ns")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestEnsureDaemonSet_UpdateWhenChanged(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+
+	// Create with default image
+	err := EnsureDaemonSet(context.Background(), client, "test-ns", ProbeImage)
+	if err != nil {
+		t.Fatalf("unexpected error on create: %v", err)
+	}
+
+	var ds appsv1.DaemonSet
+	_ = client.Get(context.Background(), types.NamespacedName{Name: ProbeName, Namespace: "test-ns"}, &ds)
+	initialRV := ds.ResourceVersion
+
+	// Update with different image
+	err = EnsureDaemonSet(context.Background(), client, "test-ns", "new-image:v2")
+	if err != nil {
+		t.Fatalf("unexpected error on update: %v", err)
+	}
+
+	_ = client.Get(context.Background(), types.NamespacedName{Name: ProbeName, Namespace: "test-ns"}, &ds)
+	if ds.ResourceVersion == initialRV {
+		t.Error("expected ResourceVersion to change after image update")
+	}
+	if ds.Spec.Template.Spec.Containers[0].Image != "new-image:v2" {
+		t.Errorf("expected new-image:v2, got %s", ds.Spec.Template.Spec.Containers[0].Image)
+	}
+}
+
+func TestMapProbePods_SkipsNonRunning(t *testing.T) {
+	runningPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "probe-node1",
+			Namespace: "test-ns",
+			Labels:    map[string]string{ProbeLabel: ProbeLabelVal},
+		},
+		Spec:   corev1.PodSpec{NodeName: "node1"},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	pendingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "probe-node2",
+			Namespace: "test-ns",
+			Labels:    map[string]string{ProbeLabel: ProbeLabelVal},
+		},
+		Spec:   corev1.PodSpec{NodeName: "node2"},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+
+	client := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(runningPod, pendingPod).Build()
+
+	probeMap, err := MapProbePods(context.Background(), client, "test-ns")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(probeMap) != 1 {
+		t.Fatalf("expected 1 running probe pod, got %d", len(probeMap))
+	}
+	if probeMap["node1"] == nil {
+		t.Error("expected running probe pod for node1")
+	}
+	if probeMap["node2"] != nil {
+		t.Error("expected no probe pod for node2 (pending)")
+	}
+}
+
+func TestMapProbePods_Empty(t *testing.T) {
+	client := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+
+	probeMap, err := MapProbePods(context.Background(), client, "test-ns")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(probeMap) != 0 {
+		t.Fatalf("expected 0 probe pods, got %d", len(probeMap))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add 8 new controller tests covering `enforceUniqueness`, `deleteStaleResults`, invalid scan interval handling, completed scan skip logic, catalog URL generation, default target namespace, and suspend-while-idle edge case
- Add 5 new probe tests covering `DeleteDaemonSet` (success + not-found), DaemonSet image update, `MapProbePods` non-running pod filtering, and empty pod list

**Coverage improvements:**
| Package | Before | After |
|---------|--------|-------|
| controller | 64.0% | 75.0% |
| probe | 56.2% | 70.8% |
| **overall** | **~49%** | **64.7%** |

## Test plan

- [x] `make lint` passes with 0 issues
- [x] `make test` passes all tests
- [x] Coverage exceeds 60% threshold