### PR TITLE
ci: add automated release workflow and VERSION support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,56 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    if: github.repository == 'sebrandon1/bps-operator'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Extract changelog for this version
+        id: changelog
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          TAG_VERSION="${RELEASE_VERSION#v}"
+
+          # Extract the section for this version from CHANGELOG.md
+          NOTES=$(awk -v ver="$TAG_VERSION" '
+            /^## \[/ {
+              if (found) exit
+              if (index($0, "[" ver "]")) found=1
+              next
+            }
+            found { print }
+          ' CHANGELOG.md)
+
+          if [ -z "$NOTES" ]; then
+            NOTES="Release ${RELEASE_VERSION}"
+          fi
+
+          # Write to file for gh release
+          echo "$NOTES" > release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          gh release create "$RELEASE_VERSION" \
+            --title "$RELEASE_VERSION" \
+            --notes-file release-notes.md

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-IMG ?= quay.io/bapalm/bps-operator:latest
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+IMG ?= quay.io/bapalm/bps-operator:$(VERSION)
 OPERATOR_NAMESPACE ?= bps-operator-system
 TEST_NAMESPACE ?= bps-test
 KIND_CLUSTER_NAME ?= kind
@@ -257,6 +258,19 @@ show-periodic-scan-yaml: ## Print the periodic scanner CR YAML
 clean: undeploy-test uninstall ## Remove everything: test workloads, CRDs, namespace
 	$(KUBECTL) delete namespace $(TEST_NAMESPACE) --ignore-not-found
 	@echo "Cleaned up."
+
+##@ Release
+
+.PHONY: release-tag
+release-tag: ## Create and push a release tag (usage: make release-tag VERSION=v0.0.4)
+	@if [ "$(VERSION)" = "$$(git describe --tags --always --dirty 2>/dev/null || echo dev)" ]; then \
+		echo "Error: specify VERSION (e.g., make release-tag VERSION=v0.0.4)"; exit 1; \
+	fi
+	@if ! echo "$(VERSION)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$'; then \
+		echo "Error: VERSION must match vX.Y.Z (got: $(VERSION))"; exit 1; \
+	fi
+	git tag -a "$(VERSION)" -m "Release $(VERSION)"
+	git push origin "$(VERSION)"
 
 ##@ Coverage
 


### PR DESCRIPTION
## Summary

- Add `.github/workflows/release.yaml` triggered by version tags (`v*`) that extracts the relevant section from `CHANGELOG.md` and creates a GitHub release with those notes
- Add `VERSION` variable to Makefile derived from `git describe --tags`
- Add `make release-tag` target for creating annotated tags with validation (must match `vX.Y.Z` format)
- Image tag now uses VERSION instead of hardcoded `latest`

The existing `image.yaml` workflow already builds and pushes images on `release` events, so tag push → release creation → image build is fully automated.

## Usage

```bash
# After updating CHANGELOG.md with the new version:
make release-tag VERSION=v0.0.4
```

## Test plan

- [x] `make lint` passes
- [ ] Push a test tag (e.g., `v0.0.4-rc.1`) to verify the workflow creates a release
- [ ] Verify the image workflow triggers on the release event