### PR TITLE
feat: add --result-ttl flag for automatic result cleanup

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -63,6 +63,7 @@ type options struct {
 	certAPIURL        string
 	nodeName          string
 	catalogURLBase    string
+	resultTTL         time.Duration
 }
 
 // parseFlags parses command-line flags from the given FlagSet and arguments.
@@ -77,6 +78,7 @@ func parseFlags(fs *flag.FlagSet, args []string) (options, error) {
 	fs.StringVar(&opts.certAPIURL, "certification-api-url", "", "Red Hat Pyxis API base URL for certification checks (default: Red Hat Catalog API).")
 	fs.StringVar(&opts.nodeName, "node-name", "", "Node name where the scanner pod runs.")
 	fs.StringVar(&opts.catalogURLBase, "catalog-url-base", "https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md", "Base URL for check catalog documentation.")
+	fs.DurationVar(&opts.resultTTL, "result-ttl", 0, "Auto-delete scan results older than this duration (e.g., 24h, 168h). 0 disables cleanup.")
 
 	if err := fs.Parse(args); err != nil {
 		return options{}, fmt.Errorf("parsing flags: %w", err)
@@ -144,6 +146,7 @@ func run(opts options, cfg *rest.Config) error {
 		K8sClientset:      k8sClientset,
 		ScaleClient:       scaleClient,
 		CatalogURLBase:    opts.catalogURLBase,
+		ResultTTL:         opts.resultTTL,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("creating controller: %w", err)
 	}

--- a/internal/controller/scanner_controller.go
+++ b/internal/controller/scanner_controller.go
@@ -39,6 +39,7 @@ type ScannerReconciler struct {
 	K8sClientset      any // kubernetes.Interface
 	ScaleClient       any // scale.ScalesGetter
 	CatalogURLBase    string
+	ResultTTL         time.Duration
 }
 
 const probeRequeueInterval = 5 * time.Second
@@ -414,9 +415,12 @@ func (r *ScannerReconciler) deleteStaleResults(ctx context.Context, scannerCR *b
 		return err
 	}
 
+	cutoff := time.Now().Add(-r.ResultTTL)
 	for i := range resultList.Items {
 		result := &resultList.Items[i]
-		if !currentNames[result.Name] {
+		stale := !currentNames[result.Name]
+		expired := r.ResultTTL > 0 && !result.Spec.Timestamp.Time.IsZero() && result.Spec.Timestamp.Time.Before(cutoff)
+		if stale || expired {
 			if err := r.Delete(ctx, result); err != nil && !apierrors.IsNotFound(err) {
 				return err
 			}

--- a/internal/controller/scanner_controller_test.go
+++ b/internal/controller/scanner_controller_test.go
@@ -557,3 +557,170 @@ func TestReconcile_SuspendAlreadyIdle(t *testing.T) {
 		t.Error("expected no requeue for suspended scanner")
 	}
 }
+
+func TestReconcile_ResultTTL(t *testing.T) {
+	s := newScheme()
+
+	scanner := &bpsv1alpha1.BestPracticeScanner{
+		ObjectMeta: metav1.ObjectMeta{Name: "scanner", Namespace: "ns"},
+		Spec: bpsv1alpha1.BestPracticeScannerSpec{
+			Checks: []string{"access-control-pod-host-network"},
+		},
+	}
+
+	oldTimestamp := metav1.NewTime(time.Now().Add(-48 * time.Hour))
+	expiredResult := &bpsv1alpha1.BestPracticeResult{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "scanner.old-expired",
+			Namespace: "ns",
+		},
+		Spec: bpsv1alpha1.BestPracticeResultSpec{
+			ScannerRef: "scanner",
+			CheckName:  "old-expired",
+			Timestamp:  oldTimestamp,
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "ns"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c1", Image: "img"}}},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(scanner, expiredResult, pod).
+		WithStatusSubresource(scanner).
+		WithIndex(&bpsv1alpha1.BestPracticeResult{}, "spec.scannerRef", func(obj client.Object) []string {
+			result := obj.(*bpsv1alpha1.BestPracticeResult)
+			return []string{result.Spec.ScannerRef}
+		}).
+		Build()
+
+	r := &ScannerReconciler{
+		Client:    c,
+		Scheme:    s,
+		Recorder:  record.NewFakeRecorder(10),
+		ResultTTL: 24 * time.Hour,
+	}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "scanner", Namespace: "ns"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var resultList bpsv1alpha1.BestPracticeResultList
+	_ = c.List(context.Background(), &resultList, client.InNamespace("ns"))
+
+	for _, r := range resultList.Items {
+		if r.Name == "scanner.old-expired" {
+			t.Error("expired result should have been deleted by TTL cleanup")
+		}
+	}
+}
+
+func TestDeleteStaleResults_ZeroTimestampNotExpired(t *testing.T) {
+	s := newScheme()
+
+	scanner := &bpsv1alpha1.BestPracticeScanner{
+		ObjectMeta: metav1.ObjectMeta{Name: "scanner", Namespace: "ns"},
+	}
+
+	zeroTimestampResult := &bpsv1alpha1.BestPracticeResult{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "scanner.current-check",
+			Namespace: "ns",
+		},
+		Spec: bpsv1alpha1.BestPracticeResultSpec{
+			ScannerRef: "scanner",
+			CheckName:  "current-check",
+		},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(scanner, zeroTimestampResult).
+		WithIndex(&bpsv1alpha1.BestPracticeResult{}, "spec.scannerRef", func(obj client.Object) []string {
+			result := obj.(*bpsv1alpha1.BestPracticeResult)
+			return []string{result.Spec.ScannerRef}
+		}).
+		Build()
+
+	r := &ScannerReconciler{
+		Client:    c,
+		Scheme:    s,
+		ResultTTL: 1 * time.Hour,
+	}
+
+	currentNames := map[string]bool{"scanner.current-check": true}
+	if err := r.deleteStaleResults(context.Background(), scanner, currentNames); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var resultList bpsv1alpha1.BestPracticeResultList
+	_ = c.List(context.Background(), &resultList, client.InNamespace("ns"))
+	if len(resultList.Items) != 1 {
+		t.Errorf("expected 1 result to survive, got %d", len(resultList.Items))
+	}
+}
+
+func TestReconcile_ResultTTL_ZeroDisablesCleanup(t *testing.T) {
+	s := newScheme()
+
+	scanner := &bpsv1alpha1.BestPracticeScanner{
+		ObjectMeta: metav1.ObjectMeta{Name: "scanner", Namespace: "ns"},
+		Spec: bpsv1alpha1.BestPracticeScannerSpec{
+			Checks: []string{"access-control-pod-host-network"},
+		},
+	}
+
+	oldTimestamp := metav1.NewTime(time.Now().Add(-48 * time.Hour))
+	oldResult := &bpsv1alpha1.BestPracticeResult{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "scanner.old-check",
+			Namespace: "ns",
+		},
+		Spec: bpsv1alpha1.BestPracticeResultSpec{
+			ScannerRef: "scanner",
+			CheckName:  "access-control-pod-host-network",
+			Timestamp:  oldTimestamp,
+		},
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "ns"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c1", Image: "img"}}},
+	}
+
+	c := fake.NewClientBuilder().WithScheme(s).
+		WithObjects(scanner, oldResult, pod).
+		WithStatusSubresource(scanner).
+		WithIndex(&bpsv1alpha1.BestPracticeResult{}, "spec.scannerRef", func(obj client.Object) []string {
+			result := obj.(*bpsv1alpha1.BestPracticeResult)
+			return []string{result.Spec.ScannerRef}
+		}).
+		Build()
+
+	r := &ScannerReconciler{
+		Client:    c,
+		Scheme:    s,
+		Recorder:  record.NewFakeRecorder(10),
+		ResultTTL: 0,
+	}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "scanner", Namespace: "ns"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var resultList bpsv1alpha1.BestPracticeResultList
+	_ = c.List(context.Background(), &resultList, client.InNamespace("ns"))
+	found := false
+	for _, r := range resultList.Items {
+		if r.Spec.CheckName == "access-control-pod-host-network" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("result should still exist when TTL is 0 (disabled)")
+	}
+}


### PR DESCRIPTION
## Summary

- Add `--result-ttl` controller flag that automatically deletes `BestPracticeResult` objects older than the specified duration (e.g., `24h`, `168h`)
- Cleanup runs after each scan completes, removing results whose `spec.timestamp` is older than the TTL cutoff
- Set to `0` (default) to retain results indefinitely
- Implemented as a controller-level flag since CRD types are now in the upstream `checks-types` repo

**Usage:**
```yaml
# In the manager deployment args:
args:
  - --result-ttl=168h  # Delete results older than 7 days
```

## Test plan

- [x] `make lint` passes with 0 issues
- [x] `make test` passes — includes tests for TTL cleanup and TTL-disabled behavior
- [ ] Deploy to Kind cluster with `--result-ttl=1m`, verify old results are deleted after scan