### PR TITLE
docs: simplify README by extracting content to docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,15 @@
 
 A Kubernetes operator that scans workloads against [certsuite](https://github.com/redhat-best-practices-for-k8s/certsuite) best practices and produces `BestPracticeResult` custom resources with per-check compliance status.
 
-## Overview
+## Key Features
 
-bps-operator watches for `BestPracticeScanner` custom resources and runs a configurable set of best-practice checks against pods, services, and other resources in the target namespace. Each check produces a `BestPracticeResult` CR recording whether the resource is compliant, non-compliant, skipped, or errored, along with remediation guidance and a link to the corresponding [certsuite CATALOG.md](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md) entry.
+- **105 checks** across 9 categories from [redhat-best-practices-for-k8s/checks](https://github.com/redhat-best-practices-for-k8s/checks)
+- **One-shot or periodic** scanning via `scanInterval` on the `BestPracticeScanner` CR
+- **Label selectors** to target specific workloads
+- **Remediation guidance** and [certsuite catalog](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md) links on every result
+- **Kubernetes-native** -- results are CRs you can query with `kubectl`
 
 ## Quick Start
-
-**Prerequisites**: A running Kubernetes or OpenShift cluster with `kubectl`/`oc` configured.
 
 ### Without Cloning
 
@@ -28,7 +30,7 @@ kubectl get bestpracticeresults -n default
 ```bash
 git clone https://github.com/sebrandon1/bps-operator.git && cd bps-operator
 
-# One-shot scan — deploys operator in-cluster, runs all checks, shows results
+# One-shot scan -- deploys operator in-cluster, runs all checks, shows results
 make deploy-scan
 
 # Or for continuous scanning every 5 minutes
@@ -42,164 +44,24 @@ make show-failures
 make clean
 ```
 
-## CRD API
+## Guides
 
-### BestPracticeScanner
-
-Defines a scan request.
-
-| Field | Type | Description |
-|---|---|---|
-| `spec.targetNamespace` | `string` | Namespace to scan (defaults to the CR's namespace) |
-| `spec.labelSelector` | `LabelSelector` | Filters which pods to scan |
-| `spec.scanInterval` | `string` | Interval between scans (e.g. `5m`, `1h30m`); validated Go duration format; omit for one-shot |
-| `spec.checks` | `[]string` | Specific checks to run (minimum 1 if specified); empty means all |
-| `spec.suspend` | `bool` | Pauses scanning when `true` |
-
-Status fields: `phase` (Idle/Scanning/Completed/Error), `lastScanTime`, `nextScanTime`, `summary` (total/compliant/nonCompliant/error/skipped counts).
-
-### BestPracticeResult
-
-Records the outcome of a single check.
-
-| Field | Type | Description |
-|---|---|---|
-| `spec.scannerRef` | `string` | Name of the scanner that produced this result |
-| `spec.checkName` | `string` | Unique check identifier |
-| `spec.category` | `string` | Check category (e.g. `access-control`) |
-| `spec.complianceStatus` | `string` | `Compliant`, `NonCompliant`, `Error`, or `Skipped` |
-| `spec.reason` | `string` | Explanation of the result |
-| `spec.remediation` | `string` | How to fix non-compliance |
-| `spec.catalogURL` | `string` | Link to the certsuite catalog entry |
-| `spec.details` | `[]ResourceDetail` | Per-resource compliance breakdown |
-
-## Checks Summary
-
-105 checks across 9 categories (provided by [redhat-best-practices-for-k8s/checks](https://github.com/redhat-best-practices-for-k8s/checks)):
-
-| Category | Count |
+| Document | Description |
 |---|---|
-| Access Control | 28 |
-| Lifecycle | 19 |
-| Platform Alteration | 15 |
-| Operator | 12 |
-| Networking | 11 |
-| Performance | 9 |
-| Observability | 5 |
-| Affiliated Certification | 4 |
-| Manageability | 2 |
+| [CRD API Reference](docs/crd-api.md) | `BestPracticeScanner` and `BestPracticeResult` field specs |
+| [Configuration](docs/configuration.md) | Scanner CR examples and field reference |
+| [Checks](docs/checks.md) | Category breakdown of all 105 checks |
+| [Architecture](docs/architecture.md) | Project layout, check library, certsuite alignment |
+| [Security Model](docs/security-model.md) | Probe DaemonSet privileges and security boundaries |
+| [Development](docs/development.md) | Full `make` target reference |
 
-## Usage
+## Development
 
-| Make Target | Description |
-|---|---|
-| `make build` | Build the operator binary |
-| `make test` | Run unit tests with coverage |
-| `make lint` | Run golangci-lint |
-| `make install` | Install CRDs onto the cluster |
-| `make install-yaml` | Generate `install.yaml` with all resources for remote deployment |
-| `make deploy` | Deploy operator to the cluster (CRDs + RBAC + manager) |
-| `make deploy-test` | Deploy test workloads only (no scanner) into `bps-test` namespace |
-| `make deploy-scan` | Deploy operator, run one-shot scan, show results |
-| `make deploy-periodic-scan` | Deploy operator, start periodic scan (5m interval) |
-| `make scan` | Alias for `deploy-scan` |
-| `make show-results` | Show scan results from the cluster |
-| `make show-failures` | Show details for all non-compliant results |
-| `make show-scan-yaml` | Print the one-shot scanner CR YAML |
-| `make show-periodic-scan-yaml` | Print the periodic scanner CR YAML |
-| `make clean` | Remove everything: test workloads, CRDs, namespace |
-| `make build-image` | Build container image |
-| `make manifests` | Regenerate CRD and RBAC manifests |
-| `make generate` | Regenerate deepcopy functions |
-
-## Configuration
-
-Create a `BestPracticeScanner` CR to configure scanning:
-
-```yaml
-apiVersion: bps.redhat-best-practices-for-k8s.com/v1alpha1
-kind: BestPracticeScanner
-metadata:
-  name: my-scanner
-  namespace: my-app
-spec:
-  targetNamespace: my-app
-  labelSelector:
-    matchLabels:
-      app: my-workload
-  scanInterval: "10m"
-  checks:
-    - access-control-sys-admin
-    - lifecycle-container-liveness
-  suspend: false
+```bash
+make build       # Build operator binary
+make test        # Unit tests with coverage
+make lint        # golangci-lint
+make manifests   # Regenerate CRD and RBAC manifests
+make deploy      # Deploy operator to the cluster
+make clean       # Remove everything
 ```
-
-- **targetNamespace**: Which namespace to scan. Defaults to the CR's own namespace.
-- **labelSelector**: Filter pods by labels. Omit to scan all pods in the namespace.
-- **scanInterval**: How often to re-scan (e.g., "5m", "1h30m", "10s"). Must be a valid Go duration string. Omit for a one-shot scan. The API validates this format at admission time, rejecting invalid durations like "5mins" or "1 hour".
-- **checks**: Run only specific checks by name. Omit to run all checks.
-- **suspend**: Set to `true` to pause periodic scanning.
-
-## Architecture
-
-```
-cmd/                     Main entrypoint
-api/v1alpha1/            CRD type definitions (BestPracticeScanner, BestPracticeResult)
-internal/
-  controller/            Reconciler for BestPracticeScanner CRs
-  scanner/               Orchestrates check execution and result creation
-  certification/         Red Hat container certification validation
-  probe/                 Probe DaemonSet for exec-based checks
-config/
-  crd/bases/             Generated CRD manifests
-  rbac/                  RBAC manifests
-  manager/               Operator Deployment manifest
-  samples/               Example CRs and test workloads
-```
-
-Check implementations are provided by the external [redhat-best-practices-for-k8s/checks](https://github.com/redhat-best-practices-for-k8s/checks) library.
-
-## Security Model
-
-### Probe DaemonSet Privileges
-
-Some compliance checks require node-level access to verify host configurations (kernel parameters, network settings, etc.). For these checks, the operator deploys a privileged DaemonSet called `certsuite-probe`.
-
-**Why Privileged Access is Required:**
-
-The probe runs with elevated privileges to enable checks such as:
-- Kernel parameter verification (sysctl settings)
-- Host file inspection (/etc, /proc, /sys)
-- Network configuration validation (iptables, routing tables)
-- Container runtime inspection
-- Security context validation
-
-**Security Boundaries:**
-
-1. **Namespace Isolation**: Probe pods run only in the operator namespace (`bps-operator-system`), not in user workload namespaces being scanned.
-
-2. **Read-Only Host Access**: The host root filesystem is mounted read-only at `/host`, preventing any modifications to nodes.
-
-3. **No Automated Execution**: The probe container runs `sleep infinity` with no automated code execution. Commands are executed only via explicit Kubernetes RBAC-controlled `pods/exec` API calls.
-
-4. **Execution Timeout**: All probe commands have a 30-second timeout to prevent runaway processes.
-
-5. **Trusted Image**: The probe image ([certsuite-probe](https://quay.io/repository/redhat-best-practices-for-k8s/certsuite-probe)) is maintained by the Red Hat Best Practices team and contains only standard Linux utilities.
-
-6. **RBAC Audit Trail**: Operators must grant `pods/exec` permissions explicitly via ClusterRole. All command executions are logged by the Kubernetes API server for audit purposes.
-
-**Checks Requiring Probe Access:**
-
-- **Platform checks**: Node configuration, OS details, kernel parameters
-- **Networking checks**: iptables rules, routing tables, interface configuration
-- **Performance checks**: CPU governor, NUMA topology, hugepages settings
-
-Checks that only inspect Kubernetes API objects (pods, services, RBAC, etc.) run directly in the operator without elevated privileges.
-
-For detailed security documentation, see [internal/probe/daemonset.go](internal/probe/daemonset.go).
-
-## Certsuite Alignment
-
-This operator implements a subset of the checks from the [certsuite](https://github.com/redhat-best-practices-for-k8s/certsuite) project as a Kubernetes-native operator. Each check's `CatalogID` maps directly to an entry in the certsuite [CATALOG.md](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md), enabling traceability between operator results and the upstream test catalog.
-
-The operator is designed to run continuously in-cluster, providing real-time compliance feedback as workloads are deployed, rather than requiring a separate test execution step.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,28 @@
+# Architecture
+
+## Project Layout
+
+```
+cmd/                     Main entrypoint
+api/v1alpha1/            CRD type definitions (BestPracticeScanner, BestPracticeResult)
+internal/
+  controller/            Reconciler for BestPracticeScanner CRs
+  scanner/               Orchestrates check execution and result creation
+  certification/         Red Hat container certification validation
+  probe/                 Probe DaemonSet for exec-based checks
+config/
+  crd/bases/             Generated CRD manifests
+  rbac/                  RBAC manifests
+  manager/               Operator Deployment manifest
+  samples/               Example CRs and test workloads
+```
+
+## Check Library
+
+Check implementations are provided by the external [redhat-best-practices-for-k8s/checks](https://github.com/redhat-best-practices-for-k8s/checks) library.
+
+## Certsuite Alignment
+
+This operator implements a subset of the checks from the [certsuite](https://github.com/redhat-best-practices-for-k8s/certsuite) project as a Kubernetes-native operator. Each check's `CatalogID` maps directly to an entry in the certsuite [CATALOG.md](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md), enabling traceability between operator results and the upstream test catalog.
+
+The operator is designed to run continuously in-cluster, providing real-time compliance feedback as workloads are deployed, rather than requiring a separate test execution step.

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -1,0 +1,15 @@
+# Checks Summary
+
+105 checks across 9 categories (provided by [redhat-best-practices-for-k8s/checks](https://github.com/redhat-best-practices-for-k8s/checks)):
+
+| Category | Count |
+|---|---|
+| Access Control | 28 |
+| Lifecycle | 19 |
+| Platform Alteration | 15 |
+| Operator | 12 |
+| Networking | 11 |
+| Performance | 9 |
+| Observability | 5 |
+| Affiliated Certification | 4 |
+| Manageability | 2 |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,29 @@
+# Configuration
+
+Create a `BestPracticeScanner` CR to configure scanning:
+
+```yaml
+apiVersion: bps.redhat-best-practices-for-k8s.com/v1alpha1
+kind: BestPracticeScanner
+metadata:
+  name: my-scanner
+  namespace: my-app
+spec:
+  targetNamespace: my-app
+  labelSelector:
+    matchLabels:
+      app: my-workload
+  scanInterval: "10m"
+  checks:
+    - access-control-sys-admin
+    - lifecycle-container-liveness
+  suspend: false
+```
+
+## Field Reference
+
+- **targetNamespace**: Which namespace to scan. Defaults to the CR's own namespace.
+- **labelSelector**: Filter pods by labels. Omit to scan all pods in the namespace.
+- **scanInterval**: How often to re-scan (e.g., "5m", "1h30m", "10s"). Must be a valid Go duration string. Omit for a one-shot scan. The API validates this format at admission time, rejecting invalid durations like "5mins" or "1 hour".
+- **checks**: Run only specific checks by name. Omit to run all checks.
+- **suspend**: Set to `true` to pause periodic scanning.

--- a/docs/crd-api.md
+++ b/docs/crd-api.md
@@ -1,0 +1,30 @@
+# CRD API Reference
+
+## BestPracticeScanner
+
+Defines a scan request.
+
+| Field | Type | Description |
+|---|---|---|
+| `spec.targetNamespace` | `string` | Namespace to scan (defaults to the CR's namespace) |
+| `spec.labelSelector` | `LabelSelector` | Filters which pods to scan |
+| `spec.scanInterval` | `string` | Interval between scans (e.g. `5m`, `1h30m`); validated Go duration format; omit for one-shot |
+| `spec.checks` | `[]string` | Specific checks to run (minimum 1 if specified); empty means all |
+| `spec.suspend` | `bool` | Pauses scanning when `true` |
+
+Status fields: `phase` (Idle/Scanning/Completed/Error), `lastScanTime`, `nextScanTime`, `summary` (total/compliant/nonCompliant/error/skipped counts).
+
+## BestPracticeResult
+
+Records the outcome of a single check.
+
+| Field | Type | Description |
+|---|---|---|
+| `spec.scannerRef` | `string` | Name of the scanner that produced this result |
+| `spec.checkName` | `string` | Unique check identifier |
+| `spec.category` | `string` | Check category (e.g. `access-control`) |
+| `spec.complianceStatus` | `string` | `Compliant`, `NonCompliant`, `Error`, or `Skipped` |
+| `spec.reason` | `string` | Explanation of the result |
+| `spec.remediation` | `string` | How to fix non-compliance |
+| `spec.catalogURL` | `string` | Link to the certsuite catalog entry |
+| `spec.details` | `[]ResourceDetail` | Per-resource compliance breakdown |

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,24 @@
+# Development
+
+## Make Targets
+
+| Make Target | Description |
+|---|---|
+| `make build` | Build the operator binary |
+| `make test` | Run unit tests with coverage |
+| `make lint` | Run golangci-lint |
+| `make install` | Install CRDs onto the cluster |
+| `make install-yaml` | Generate `install.yaml` with all resources for remote deployment |
+| `make deploy` | Deploy operator to the cluster (CRDs + RBAC + manager) |
+| `make deploy-test` | Deploy test workloads only (no scanner) into `bps-test` namespace |
+| `make deploy-scan` | Deploy operator, run one-shot scan, show results |
+| `make deploy-periodic-scan` | Deploy operator, start periodic scan (5m interval) |
+| `make scan` | Alias for `deploy-scan` |
+| `make show-results` | Show scan results from the cluster |
+| `make show-failures` | Show details for all non-compliant results |
+| `make show-scan-yaml` | Print the one-shot scanner CR YAML |
+| `make show-periodic-scan-yaml` | Print the periodic scanner CR YAML |
+| `make clean` | Remove everything: test workloads, CRDs, namespace |
+| `make build-image` | Build container image |
+| `make manifests` | Regenerate CRD and RBAC manifests |
+| `make generate` | Regenerate deepcopy functions |

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -1,0 +1,38 @@
+# Security Model
+
+## Probe DaemonSet Privileges
+
+Some compliance checks require node-level access to verify host configurations (kernel parameters, network settings, etc.). For these checks, the operator deploys a privileged DaemonSet called `certsuite-probe`.
+
+### Why Privileged Access is Required
+
+The probe runs with elevated privileges to enable checks such as:
+- Kernel parameter verification (sysctl settings)
+- Host file inspection (/etc, /proc, /sys)
+- Network configuration validation (iptables, routing tables)
+- Container runtime inspection
+- Security context validation
+
+### Security Boundaries
+
+1. **Namespace Isolation**: Probe pods run only in the operator namespace (`bps-operator-system`), not in user workload namespaces being scanned.
+
+2. **Read-Only Host Access**: The host root filesystem is mounted read-only at `/host`, preventing any modifications to nodes.
+
+3. **No Automated Execution**: The probe container runs `sleep infinity` with no automated code execution. Commands are executed only via explicit Kubernetes RBAC-controlled `pods/exec` API calls.
+
+4. **Execution Timeout**: All probe commands have a 30-second timeout to prevent runaway processes.
+
+5. **Trusted Image**: The probe image ([certsuite-probe](https://quay.io/repository/redhat-best-practices-for-k8s/certsuite-probe)) is maintained by the Red Hat Best Practices team and contains only standard Linux utilities.
+
+6. **RBAC Audit Trail**: Operators must grant `pods/exec` permissions explicitly via ClusterRole. All command executions are logged by the Kubernetes API server for audit purposes.
+
+### Checks Requiring Probe Access
+
+- **Platform checks**: Node configuration, OS details, kernel parameters
+- **Networking checks**: iptables rules, routing tables, interface configuration
+- **Performance checks**: CPU governor, NUMA topology, hugepages settings
+
+Checks that only inspect Kubernetes API objects (pods, services, RBAC, etc.) run directly in the operator without elevated privileges.
+
+For detailed security documentation, see [internal/probe/daemonset.go](../internal/probe/daemonset.go).


### PR DESCRIPTION
## Summary

Slims the README from a 206-line monolith into a 67-line landing page by extracting detailed content into focused docs/ files. No content was removed.

- **Before:** 206 lines (single README.md)
- **After:** 67 lines (README.md) + 164 lines across 6 docs/ files

## Changes

| File | Action | Lines |
|---|---|---|
| `README.md` | Rewritten as landing page | 67 |
| `docs/crd-api.md` | Extracted CRD field reference | 30 |
| `docs/configuration.md` | Extracted scanner CR config guide | 29 |
| `docs/architecture.md` | Extracted project layout + certsuite alignment | 28 |
| `docs/security-model.md` | Extracted probe DaemonSet security docs | 38 |
| `docs/checks.md` | Extracted checks category breakdown | 15 |
| `docs/development.md` | Extracted full make target reference | 24 |

## Guides Table (new in README)

| Document | Description |
|---|---|
| CRD API Reference | BestPracticeScanner and BestPracticeResult field specs |
| Configuration | Scanner CR examples and field reference |
| Checks | Category breakdown of all 105 checks |
| Architecture | Project layout, check library, certsuite alignment |
| Security Model | Probe DaemonSet privileges and security boundaries |
| Development | Full make target reference |

## Test plan

- [ ] All links in README resolve to correct docs/ files
- [ ] No content from original README was lost
- [ ] README renders correctly on GitHub
- [ ] docs/ files render correctly on GitHub

## Related to

- sebrandon1/tls-compliance-operator [#209](https://github.com/sebrandon1/tls-compliance-operator/pull/209)
- sebrandon1/imagecertinfo-operator [#115](https://github.com/sebrandon1/imagecertinfo-operator/pull/115)
- sebrandon1/tls-config-lint [#16](https://github.com/sebrandon1/tls-config-lint/pull/16)
- openshift-kni/olm-annotation-lint [#50](https://github.com/openshift-kni/olm-annotation-lint/pull/50)
- sebrandon1/succulent-cli [#59](https://github.com/sebrandon1/succulent-cli/pull/59)
- sebrandon1/ocp-doc-checker [#55](https://github.com/sebrandon1/ocp-doc-checker/pull/55)
- sebrandon1/go-quay [#111](https://github.com/sebrandon1/go-quay/pull/111)
- sebrandon1/compliance-scripts [#122](https://github.com/sebrandon1/compliance-scripts/pull/122)
- sebrandon1/go-skylight [#175](https://github.com/sebrandon1/go-skylight/pull/175)
- sebrandon1/go-enphase [#22](https://github.com/sebrandon1/go-enphase/pull/22)
- sebrandon1/skylight-bridge [#18](https://github.com/sebrandon1/skylight-bridge/pull/18)
- sebrandon1/ztp-dashboard [#117](https://github.com/sebrandon1/ztp-dashboard/pull/117)
- sebrandon1/yaml-to-readme [#153](https://github.com/sebrandon1/yaml-to-readme/pull/153)
- sebrandon1/grab [#42](https://github.com/sebrandon1/grab/pull/42)
- sebrandon1/jiracrawler [#84](https://github.com/sebrandon1/jiracrawler/pull/84)
- sebrandon1/compliance-operator-dashboard [#121](https://github.com/sebrandon1/compliance-operator-dashboard/pull/121)