### PR TITLE
ci: fix e2e-ocp flaky rollout and add OCP 4.20 workflow

### DIFF
--- a/.github/workflows/e2e-ocp-4.20.yaml
+++ b/.github/workflows/e2e-ocp-4.20.yaml
@@ -1,4 +1,4 @@
-name: E2E OCP 4.22 Tests
+name: E2E OCP 4.20 Tests
 
 on:
   push:
@@ -53,7 +53,7 @@ jobs:
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true
-          desiredOCPVersion: 4.22
+          desiredOCPVersion: 4.20
           waitForOperatorsReady: true
         env:
           OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}

--- a/.github/workflows/e2e-ocp-4.22.yaml
+++ b/.github/workflows/e2e-ocp-4.22.yaml
@@ -1,0 +1,169 @@
+name: E2E OCP 4.22 Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * *" # Nightly at 06:00 UTC
+
+# Only run on upstream (sebrandon1) repo and non-dependabot PRs — skip contexts that lack required secrets
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions: read-all
+
+jobs:
+  e2e-ocp:
+    if: github.repository == 'sebrandon1/bps-operator' && github.actor != 'dependabot[bot]'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    env:
+      KUBECONFIG: '/home/runner/.crc/machines/crc/kubeconfig'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
+      - name: Install controller-gen
+        run: go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+
+      - name: Check if CRC_PULL_SECRET exists
+        env:
+          super_secret: ${{ secrets.CRC_PULL_SECRET }}
+        if: ${{ env.super_secret == '' }}
+        run: |
+          echo "CRC_PULL_SECRET is not set"
+          exit 1
+
+      - name: Build and save image
+        run: |
+          docker build -t bps-operator:e2e .
+          docker save bps-operator:e2e -o ${GITHUB_WORKSPACE}/bps-operator.tar
+
+      - name: Deploy OCP cluster
+        uses: palmsoftware/quick-ocp@a45d68e21f19d4f7b4e582a54379345982106a04 # v0.0.34
+        with:
+          ocpPullSecret: $OCP_PULL_SECRET
+          bundleCache: true
+          desiredOCPVersion: 4.22
+          waitForOperatorsReady: true
+        env:
+          OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
+
+      - name: Push image to OpenShift internal registry
+        run: |
+          # Reload image (quick-ocp disk cleanup removes docker images)
+          docker load -i ${GITHUB_WORKSPACE}/bps-operator.tar
+
+          # Login to get a token (KUBECONFIG uses client certs, not tokens)
+          KUBEADMIN_PASS=$(cat ~/.crc/machines/crc/kubeadmin-password)
+          oc login -u kubeadmin -p "$KUBEADMIN_PASS" https://api.crc.testing:6443 --insecure-skip-tls-verify
+
+          # Expose the internal registry via default route
+          oc patch configs.imageregistry.operator.openshift.io/cluster --type merge -p '{"spec":{"defaultRoute":true}}'
+          sleep 10
+
+          # Get the registry route
+          REGISTRY=$(oc get route default-route -n openshift-image-registry -o jsonpath='{.spec.host}')
+          echo "Registry: $REGISTRY"
+
+          # Login to the internal registry with the token
+          docker login -u kubeadmin -p "$(oc whoami -t)" "$REGISTRY"
+
+          # Create the namespace for the image
+          oc new-project bps-operator-system 2>/dev/null || true
+
+          # Tag and push
+          REMOTE_IMG="$REGISTRY/bps-operator-system/bps-operator:e2e"
+          docker tag bps-operator:e2e "$REMOTE_IMG"
+          docker push "$REMOTE_IMG"
+
+          # Save the internal image reference for later steps
+          echo "INTERNAL_IMG=image-registry.openshift-image-registry.svc:5000/bps-operator-system/bps-operator:e2e" >> "$GITHUB_ENV"
+
+      - name: Deploy operator
+        run: |
+          make manifests
+          oc apply -f config/crd/bases/
+          oc apply -f config/rbac/
+
+          # Inject the correct image before applying to avoid a double rollout.
+          # Applying with the default quay.io image then immediately patching
+          # triggers two competing rollouts that race on CRC's limited resources.
+          sed -i "s|quay.io/bapalm/bps-operator:latest|$INTERNAL_IMG|g" config/manager/manager.yaml
+          oc apply -f config/manager/
+
+      - name: Wait for operator to be ready
+        run: oc rollout status deployment/bps-operator-controller-manager -n bps-operator-system --timeout=300s
+
+      - name: Debug operator failure
+        if: failure()
+        run: |
+          echo "=== Pod Status ==="
+          oc get pods -n bps-operator-system -o wide
+          echo ""
+          echo "=== Pod Describe ==="
+          oc describe pods -n bps-operator-system
+          echo ""
+          echo "=== Events ==="
+          oc get events -n bps-operator-system --sort-by='.lastTimestamp'
+          echo ""
+          echo "=== Operator Logs ==="
+          oc logs deployment/bps-operator-controller-manager -n bps-operator-system --tail=100 2>/dev/null || true
+
+      - name: Deploy test workloads and scanner
+        run: |
+          oc apply -f config/samples/test-workloads.yaml
+          oc wait --for=jsonpath='{.status.phase}'=Active namespace/bps-test --timeout=10s
+          oc apply -f config/samples/scanner_bps_test.yaml
+
+      - name: Wait for scan to complete
+        run: |
+          for i in $(seq 1 180); do
+            PHASE=$(oc get bestpracticescanners test-scanner -n bps-test -o jsonpath='{.status.phase}' 2>/dev/null)
+            if [ "$PHASE" = "Completed" ]; then echo "Scan completed."; break; fi
+            if [ "$PHASE" = "Error" ]; then
+              echo "Scan failed with Error phase"
+              oc logs deployment/bps-operator-controller-manager -n bps-operator-system --tail=50
+              exit 1
+            fi
+            if [ $i -eq 180 ]; then
+              echo "Timed out waiting for scan (phase: $PHASE)"
+              oc logs deployment/bps-operator-controller-manager -n bps-operator-system --tail=50
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Show results
+        if: always()
+        run: |
+          echo "=== Scanner Status ==="
+          oc get bestpracticescanners test-scanner -n bps-test -o yaml 2>/dev/null | grep -A 10 "status:" || true
+          echo ""
+          echo "=== Results ==="
+          oc get bestpracticeresults -n bps-test 2>/dev/null || true
+
+      - name: Verify check count
+        run: |
+          TOTAL=$(oc get bestpracticescanners test-scanner -n bps-test -o jsonpath='{.status.summary.total}')
+          ERRORS=$(oc get bestpracticescanners test-scanner -n bps-test -o jsonpath='{.status.summary.error}')
+          echo "Total checks: $TOTAL, Errors: $ERRORS"
+          if [ "$TOTAL" -lt 100 ]; then
+            echo "Expected at least 100 checks, got $TOTAL"
+            exit 1
+          fi
+          if [ "$ERRORS" -gt 0 ]; then
+            echo "Expected 0 errors, got $ERRORS"
+            echo "=== Error details ==="
+            oc get bestpracticeresults -n bps-test -o jsonpath='{range .items[?(@.spec.complianceStatus=="Error")]}{.spec.checkName}{"\t"}{.spec.reason}{"\n"}{end}'
+            exit 1
+          fi

--- a/.github/workflows/e2e-ocp.yaml
+++ b/.github/workflows/e2e-ocp.yaml
@@ -94,13 +94,30 @@ jobs:
           make manifests
           oc apply -f config/crd/bases/
           oc apply -f config/rbac/
+
+          # Inject the correct image before applying to avoid a double rollout.
+          # Applying with the default quay.io image then immediately patching
+          # triggers two competing rollouts that race on CRC's limited resources.
+          sed -i "s|quay.io/bapalm/bps-operator:latest|$INTERNAL_IMG|g" config/manager/manager.yaml
           oc apply -f config/manager/
-          oc set image deployment/bps-operator-controller-manager manager=$INTERNAL_IMG -n bps-operator-system
-          oc patch deployment bps-operator-controller-manager -n bps-operator-system \
-            -p '{"spec":{"template":{"spec":{"containers":[{"name":"manager","imagePullPolicy":"Always"}]}}}}'
 
       - name: Wait for operator to be ready
-        run: oc rollout status deployment/bps-operator-controller-manager -n bps-operator-system --timeout=120s
+        run: oc rollout status deployment/bps-operator-controller-manager -n bps-operator-system --timeout=300s
+
+      - name: Debug operator failure
+        if: failure()
+        run: |
+          echo "=== Pod Status ==="
+          oc get pods -n bps-operator-system -o wide
+          echo ""
+          echo "=== Pod Describe ==="
+          oc describe pods -n bps-operator-system
+          echo ""
+          echo "=== Events ==="
+          oc get events -n bps-operator-system --sort-by='.lastTimestamp'
+          echo ""
+          echo "=== Operator Logs ==="
+          oc logs deployment/bps-operator-controller-manager -n bps-operator-system --tail=100 2>/dev/null || true
 
       - name: Deploy test workloads and scanner
         run: |


### PR DESCRIPTION
## Summary

- **Eliminate double rollout** (e2e-ocp.yaml): The deploy step was applying the deployment with the default `quay.io/bapalm/bps-operator:latest` image, then immediately running `oc set image` + `oc patch`, triggering two competing rollouts that raced on CRC's limited resources. Now we `sed` the correct internal registry image into `manager.yaml` before applying — single rollout, no race.
- **Increase rollout timeout**: 120s to 300s as a safety net for CRC resource pressure.
- **Add debug step on failure**: New `if: failure()` step dumps pod status, pod describe, namespace events, and operator logs so future failures have actual diagnostics.
- **Add OCP 4.20 E2E workflow** (e2e-ocp-4.20.yaml): New workflow targeting OCP 4.20, staggered to run nightly at 06:00 UTC (2 hours after the 4.21 workflow). Includes all the same fixes. Provides coverage across two supported OCP releases.

## Context

The e2e-ocp workflow has been failing intermittently at the "Wait for operator to be ready" step. All recent failures show the same pattern: `oc rollout status` cycles for 120 seconds between "1 old replicas are pending termination" and "0 of 1 updated replicas are available" before timing out. Successful runs show the same cycling but settle within ~43 seconds. The difference is CRC resource pressure — the double rollout creates contention between old and new pods.

## Test plan

- [ ] Verify PR CI passes (e2e-ocp workflows run on PRs to main)
- [ ] Monitor next few nightly runs for stability on both 4.20 and 4.21