### PR TITLE
Split lint job into parallel linters

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -11,7 +11,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  lint:
+  golangci-lint:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
@@ -27,8 +27,25 @@ jobs:
         with:
           args: --timeout 5m
 
+  go-vet:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: go.mod
+
       - name: go vet
         run: make vet
+
+  hadolint:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Hadolint
         uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
@@ -36,7 +53,7 @@ jobs:
           dockerfile: Dockerfile
 
   test:
-    needs: lint
+    needs: [golangci-lint, go-vet]
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
@@ -65,7 +82,7 @@ jobs:
           fi
 
   build:
-    needs: lint
+    needs: [golangci-lint, go-vet]
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

Split the monolithic lint job into 3 independent parallel jobs to reduce CI time.

## Changes

- **golangci-lint**, **go vet**, and **hadolint** now run as separate parallel jobs
- test and build jobs depend only on Go linters (golangci-lint, go-vet)
- hadolint runs independently since it only validates the Dockerfile

## Expected Benefit

**Time savings: 30-60 seconds per run** - Linters run in parallel and test/build start as soon as Go linters complete (without waiting for hadolint).

## Testing

The changes will be validated when CI runs on this PR.

## Related PRs

**Personal repos (sebrandon1):**
- compliance-scripts: https://github.com/sebrandon1/compliance-scripts/pull/166
- go-dci: https://github.com/sebrandon1/go-dci/pull/143
- ocp-doc-checker: https://github.com/sebrandon1/ocp-doc-checker/pull/57

**Organization repos (redhat-best-practices-for-k8s):**
- certsuite: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3748
- checks: https://github.com/redhat-best-practices-for-k8s/checks/pull/48
- checks-qe: https://github.com/redhat-best-practices-for-k8s/checks-qe/pull/39
- operator-results-spreadsheet: https://github.com/redhat-best-practices-for-k8s/operator-results-spreadsheet/pull/46